### PR TITLE
added environment to Stack resource class

### DIFF
--- a/ecl/orchestration/v1/stack.py
+++ b/ecl/orchestration/v1/stack.py
@@ -73,6 +73,8 @@ class Stack(resource.Resource):
     updated_at = resource.Body('updated_time')
     #: The ID of the user project created for this stack.
     user_project_id = resource.Body('stack_user_project_id')
+    #: A Environment information for stack
+    environment = resource.Body('environment', type=dict)
 
 
     def stack_prepare_request(self, session, requires_id=True, prepend_key=False):

--- a/ecl/tests/unit/orchestration/v1/test_stack.py
+++ b/ecl/tests/unit/orchestration/v1/test_stack.py
@@ -40,6 +40,7 @@ FAKE = {
     'template_url': 'http://www.example.com/wordpress.yaml',
     'timeout_mins': '14',
     'updated_time': '2015-03-09T12:30:00.000000',
+    'environment': {'network_id': 'ad936ae4-2983-4f23-9187-e47e82cb2725'},
 }
 FAKE_CREATE_RESPONSE = {
     'stack': {
@@ -85,6 +86,7 @@ class TestStack(testtools.TestCase):
         self.assertEqual(FAKE['template_url'], sot.template_url)
         self.assertEqual(FAKE['timeout_mins'], sot.timeout_mins)
         self.assertEqual(FAKE['updated_time'], sot.updated_at)
+        self.assertEqual(FAKE['environment'], sot.environment)
 
     @mock.patch.object(resource.Resource, 'create')
     def test_create(self, mock_create):


### PR DESCRIPTION
Current eclsdk does not support the environment file for Heat stack.  Added one property "environment" into Stack resource class.