### PR TITLE
Add virtual network appliance exception handling

### DIFF
--- a/ecl/exceptions.py
+++ b/ecl/exceptions.py
@@ -92,10 +92,6 @@ class HttpException(SDKException):
                     and content.get(self.api_error_key):
                 return content[self.api_error_key]
 
-            # provider connectivity case
-            if hasattr(self, 'cause'):
-                return content["cause"]
-
             # Default case.
             if content.get('message'):
                 return content['message']

--- a/ecl/provider_connectivity/exceptions.py
+++ b/ecl/provider_connectivity/exceptions.py
@@ -6,7 +6,7 @@ from ecl import exceptions
 
 
 class HttpException(exceptions.HttpException):
-    pass
+    api_error_key = 'cause'
 
 
 class NotFoundException(HttpException):

--- a/ecl/virtual_network_appliance/exceptions.py
+++ b/ecl/virtual_network_appliance/exceptions.py
@@ -6,7 +6,31 @@ from ecl import exceptions
 
 
 class HttpException(exceptions.HttpException):
-    pass
+
+    def _get_exception_message(self):
+        try:
+            content = json.loads(self.response._content)
+
+            # API-GW
+            if 'fault' in content and 'faultstring' in content['fault']:
+                return content['fault']['faultstring']
+
+            # IAM error case.
+            if content.get('errorMessage'):
+                return content[self.api_error_key]
+
+            # In VNA API, we need to handle both "cause" and "message" key
+            # as API error.
+            k = content.keys()
+            if 'message' in k and 'cause' not in k:
+                return content['message']
+            if 'cause' in k and 'message' not in k:
+                return content['cause']
+        except:
+            pass
+
+        # In case parse failed.
+        return 'Unknown Exception'
 
 
 class NotFoundException(HttpException):


### PR DESCRIPTION
This PR enables user to read error keys from VNA API correctly.
To fix above, I’ve changed following.
- move provider-connectivity error logic into inside of API’s exception.
  (add api_error_key to API’s exception class)
- Add entry for VNA exception into ecl/exceptions.py
- Add own json parse logic to VNA exceptions.py