### PR TITLE
Enable to extract operations which relates to specified vna only

### DIFF
--- a/ecl/virtual_network_appliance/v1/_proxy.py
+++ b/ecl/virtual_network_appliance/v1/_proxy.py
@@ -203,17 +203,19 @@ class Proxy(proxy2.BaseProxy):
             self.get_virtual_network_appliance(virtual_network_appliance)
         return virtual_network_appliance.reset_password(self.session)
 
-    def operations(self, **params):
+    def operations(self, resource_ids=[]):
         """List operations.
 
-        :param params: The parameters as query string
-            to get operations by specified condition.
+        :param resource_ids: The list of resouce(appliance) IDs.
+            If user specify this parameter,
+            operations that has resource_id attribute is included in
+            this list will be returned.
         :returns: A list of operation objects
         :rtype: list of :class:`~ecl.virtual_network_appliance.v1.
             operation.Operation`
         """
         return list(self._list(_operation.Operation, paginated=False,
-                               **params))
+                               resource_ids=resource_ids))
 
     def get_operation(
             self, operation_id):


### PR DESCRIPTION
In operations API, user can specify
resource_id query parameter for multiple times.

But SDK’s regular list API does not have this structure.
And operation API only allows basically resource_id.

So I’ve changed argument of list method
from dict to list.
And inside of this method, combine those parameters
like ‘?resource_id=A&resoruce_id=B, …’

This enable GUI o extract minimum size or response.