### PR TITLE
Make get_virtual_network_appliance_plan method receive query parameters

### DIFF
--- a/ecl/resource2.py
+++ b/ecl/resource2.py
@@ -572,17 +572,13 @@ class Resource(object):
         self._translate_response(response)
         return self
 
-    def get(self, session, requires_id=True, **params):
+    def get(self, session, requires_id=True):
         """Get a remote resource based on this instance.
 
         :param session: The session to use for making this request.
         :type session: :class:`~ecl.session.Session`
         :param boolean requires_id: A boolean indicating whether resource ID
                                     should be part of the requested URI.
-        :param dict params: Parameters to be passed onto the
-                            :meth:`~ecl.session.Session.get` method.
-                            These are used as query parameters
-                            with GET request.
         :return: This :class:`Resource` instance.
         :raises: :exc:`~ecl.exceptions.MethodNotSupported` if
                  :data:`Resource.allow_get` is not set to ``True``.
@@ -591,10 +587,7 @@ class Resource(object):
             raise exceptions.MethodNotSupported(self, "get")
 
         request = self._prepare_request(requires_id=requires_id)
-        query_params = self._query_mapping._transpose(params)
-        response = session.get(request.uri,
-                               endpoint_filter=self.service,
-                               params=query_params)
+        response = session.get(request.uri, endpoint_filter=self.service)
 
         self._translate_response(response)
         return self

--- a/ecl/resource2.py
+++ b/ecl/resource2.py
@@ -572,13 +572,17 @@ class Resource(object):
         self._translate_response(response)
         return self
 
-    def get(self, session, requires_id=True):
+    def get(self, session, requires_id=True, **params):
         """Get a remote resource based on this instance.
 
         :param session: The session to use for making this request.
         :type session: :class:`~ecl.session.Session`
         :param boolean requires_id: A boolean indicating whether resource ID
                                     should be part of the requested URI.
+        :param dict params: Parameters to be passed onto the
+                            :meth:`~ecl.session.Session.get` method.
+                            These are used as query parameters
+                            with GET request.
         :return: This :class:`Resource` instance.
         :raises: :exc:`~ecl.exceptions.MethodNotSupported` if
                  :data:`Resource.allow_get` is not set to ``True``.
@@ -587,7 +591,10 @@ class Resource(object):
             raise exceptions.MethodNotSupported(self, "get")
 
         request = self._prepare_request(requires_id=requires_id)
-        response = session.get(request.uri, endpoint_filter=self.service)
+        query_params = self._query_mapping._transpose(params)
+        response = session.get(request.uri,
+                               endpoint_filter=self.service,
+                               params=query_params)
 
         self._translate_response(response)
         return self

--- a/ecl/virtual_network_appliance/v1/_proxy.py
+++ b/ecl/virtual_network_appliance/v1/_proxy.py
@@ -36,7 +36,9 @@ class Proxy(proxy2.BaseProxy):
         """
         return self._get(
             _virtual_network_appliance_plan.VirtualNetworkAppliancePlan,
-            virtual_network_appliance_plan_id, True, **params)
+            virtual_network_appliance_plan_id,
+            **params
+        )
 
     def virtual_network_appliances(self, **params):
         """List virtual network appliances.

--- a/ecl/virtual_network_appliance/v1/_proxy.py
+++ b/ecl/virtual_network_appliance/v1/_proxy.py
@@ -5,10 +5,39 @@ from ecl.virtual_network_appliance.v1 \
 from ecl.virtual_network_appliance.v1 \
     import virtual_network_appliance_plan as _virtual_network_appliance_plan
 from ecl.virtual_network_appliance.v1 import operation as _operation
+from ecl import exceptions
 from ecl import proxy2
 
 
 class Proxy(proxy2.BaseProxy):
+
+    @proxy2._check_resource(strict=False)
+    def _get(self, resource_type, value=None, requires_id=True, **params):
+        """Get a resource
+
+        :param resource_type: The type of resource to get.
+        :type resource_type: :class:`~ecl.resource2.Resource`
+        :param value: The value to get. Can be either the ID of a
+                      resource or a :class:`~ecl.resource2.Resource`
+                      subclass.
+        :param dict params: Parameters to be passed onto the
+                            :meth:`~ecl.resource2.Resource.get` method.
+                            These are used as query parameters
+                            with GET request.
+        :returns: The result of the ``get``
+        :rtype: :class:`~ecl.resource2.Resource`
+        """
+        res = self._get_resource(resource_type, value)
+
+        try:
+            return res.get(self.session, requires_id=requires_id, **params)
+        except exceptions.NotFoundException as e:
+            raise exceptions.ResourceNotFound(
+                message="No %s found for %s" %
+                        (resource_type.__name__, value),
+                details=e.details, response=e.response,
+                request_id=e.request_id, url=e.url, method=e.method,
+                http_status=e.http_status, cause=e.cause)
 
     def virtual_network_appliance_plans(self, **params):
         """List virtual network appliance plans.

--- a/ecl/virtual_network_appliance/v1/_proxy.py
+++ b/ecl/virtual_network_appliance/v1/_proxy.py
@@ -24,17 +24,19 @@ class Proxy(proxy2.BaseProxy):
             paginated=False, **params))
 
     def get_virtual_network_appliance_plan(
-            self, virtual_network_appliance_plan_id):
+            self, virtual_network_appliance_plan_id, **params):
         """Show virtual network appliance plan.
 
         :param string virtual_network_appliance_plan_id:
             ID of specified virtual network appliance plan.
+        :param params: The parameters as query string format
+            to get a network appliance plan.
         :return: :class:`~ecl.virtual_network_appliance.v1.
             virtual_network_appliance_plan.VirtualNetworkAppliancePlan`
         """
         return self._get(
             _virtual_network_appliance_plan.VirtualNetworkAppliancePlan,
-            virtual_network_appliance_plan_id)
+            virtual_network_appliance_plan_id, True, **params)
 
     def virtual_network_appliances(self, **params):
         """List virtual network appliances.


### PR DESCRIPTION
We want to pass a query parameter(details=false) when getting a virtual network appliance plan. So I made get_virtual_network_appliance_plan receive query parameters as 'params' argument.