### PR TITLE
Fix openstacksdk version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ six>=1.9.0 # MIT
 stevedore>=1.16.0 # Apache-2.0
 os-client-config!=1.19.0,>=1.13.1 # Apache-2.0
 keystoneauth1<=3.4.0,>=2.10.0 # Apache-2.0
+openstacksdk<=0.13.0 # Apache-2.0


### PR DESCRIPTION
We need to use openstacksdk 0.13.0 because later versions do not satisfy our keystoneauth1 requirement.