### PR TITLE
:wrench: IF-3839 Add parameters to dns recordset list command

### DIFF
--- a/ecl/dns/v2/_proxy.py
+++ b/ecl/dns/v2/_proxy.py
@@ -124,13 +124,20 @@ class Proxy(proxy2.BaseProxy):
         """
         return list(self._list(name_server.NameServer, zone_id=zone_id))
 
-    def recordsets(self, zone_id):
+    def recordsets(self, zone_id, limit, marker):
         """
         This lists all recordsets in a zone.
         :param zone_id: ID for the zone
+        :param limit:Requests a page size of items. Returns a number of items up to a limit value. Use the limit parameter to make an initial limited request and use the ID of the last-seen item from the response as the marker parameter value in a subsequent limited request.
+        :param marker: The ID of the last-seen item. Use the limit parameter to make an initial limited request and use the ID of the last-seen item from the response as the marker parameter value in a subsequent limited request.
         :return: One list of :class:`~ecl.dns.v2.recordsets.Recordsets`
         """
-        return list(self._list(_recordset.RecordSet, zone_id=zone_id))
+        attrs = {}
+        attrs["zone_id"] = zone_id
+        attrs["limit"] = limit
+        attrs["marker"] = marker
+
+        return list(self._list(_recordset.RecordSet, **attrs))
 
     def get_recordset(self, zone_id, recordset_id):
         """

--- a/ecl/dns/v2/_proxy.py
+++ b/ecl/dns/v2/_proxy.py
@@ -124,18 +124,20 @@ class Proxy(proxy2.BaseProxy):
         """
         return list(self._list(name_server.NameServer, zone_id=zone_id))
 
-    def recordsets(self, zone_id, limit, marker):
+    def recordsets(self, zone_id, limit=None, marker=None):
         """
         This lists all recordsets in a zone.
         :param zone_id: ID for the zone
-        :param limit:Requests a page size of items. Returns a number of items up to a limit value. Use the limit parameter to make an initial limited request and use the ID of the last-seen item from the response as the marker parameter value in a subsequent limited request.
+        :param limit: Requests a page size of items(1-500). Returns a number of items up to a limit value. Use the limit parameter to make an initial limited request and use the ID of the last-seen item from the response as the marker parameter value in a subsequent limited request.
         :param marker: The ID of the last-seen item. Use the limit parameter to make an initial limited request and use the ID of the last-seen item from the response as the marker parameter value in a subsequent limited request.
         :return: One list of :class:`~ecl.dns.v2.recordsets.Recordsets`
         """
         attrs = {}
         attrs["zone_id"] = zone_id
-        attrs["limit"] = limit
-        attrs["marker"] = marker
+        if limit is not None:
+            attrs["limit"] = limit
+        if marker is not None:
+            attrs["marker"] = marker
 
         return list(self._list(_recordset.RecordSet, **attrs))
 

--- a/ecl/dns/v2/recordset.py
+++ b/ecl/dns/v2/recordset.py
@@ -28,6 +28,8 @@ class RecordSet(resource2.Resource):
     allow_list = True
     allow_get = True
 
+    _query_mapping = resource2.QueryParameters("zone_id", "marker", "limit")
+
     # Properties
     #: ID for the resource
     id = resource2.Body('id')

--- a/ecl/dns/v2/recordset.py
+++ b/ecl/dns/v2/recordset.py
@@ -28,7 +28,7 @@ class RecordSet(resource2.Resource):
     allow_list = True
     allow_get = True
 
-    _query_mapping = resource2.QueryParameters("zone_id", "marker", "limit")
+    _query_mapping = resource2.QueryParameters("limit", "marker")
 
     # Properties
     #: ID for the resource


### PR DESCRIPTION
We added a parameter to be passed to the API that displays a list of record sets associated with the zone of DNS and fixed it so that pagination can be done.

Parameters added

limit: Number of records set display.
marker: Specifies the UUID of the record and displays it from the record next to the specified record.