### PR TITLE
:bug: IF-4057 Modify unicode objects to be encoded in python3

### DIFF
--- a/ecl/provider_connectivity/v1/address_assignment.py
+++ b/ecl/provider_connectivity/v1/address_assignment.py
@@ -45,7 +45,7 @@ class AddressAssignment(resource2.Resource):
             # case and it involves looping through the class' dict.
             id = value.id or getattr(
                 value, value._alternate_id(),
-                hashlib.new('md5', str(value)).hexdigest())
+                hashlib.new('md5', str(value).encode('utf-8')).hexdigest())
             return id
         else:
             return value
@@ -63,7 +63,7 @@ class AddressAssignment(resource2.Resource):
             elif self._alternate_id():
                 return self._body[self._alternate_id()]
             else:
-                return hashlib.new('md5', str(self)).hexdigest()
+                return hashlib.new('md5', str(self).encode('utf-8')).hexdigest()
         else:
             return object.__getattribute__(self, name)
 

--- a/ecl/provider_connectivity/v2/address_assignment.py
+++ b/ecl/provider_connectivity/v2/address_assignment.py
@@ -45,7 +45,7 @@ class AddressAssignment(resource2.Resource):
             # case and it involves looping through the class' dict.
             id = value.id or getattr(
                 value, value._alternate_id(),
-                hashlib.new('md5', str(value)).hexdigest())
+                hashlib.new('md5', str(value).encode('utf-8')).hexdigest())
             return id
         else:
             return value
@@ -63,7 +63,7 @@ class AddressAssignment(resource2.Resource):
             elif self._alternate_id():
                 return self._body[self._alternate_id()]
             else:
-                return hashlib.new('md5', str(self)).hexdigest()
+                return hashlib.new('md5', str(self).encode('utf-8')).hexdigest()
         else:
             return object.__getattribute__(self, name)
 


### PR DESCRIPTION
Fix unicode objects to be encoded correctly before hashing in order to resolve the following error in python3 environment.

```
(ecl) icc address-assignment list ${RESOURCE_UUID}
Unicode-objects must be encoded before hashing
```