### PR TITLE
:bug: IF-8337 Add Version to Head of URL Path

### DIFF
--- a/ecl/managed_rdb/mrdb_service.py
+++ b/ecl/managed_rdb/mrdb_service.py
@@ -18,7 +18,7 @@ class MrdbService(service_filter.ServiceFilter):
 
     valid_versions = [service_filter.ValidVersion('v1')]
 
-    def __init__(self, version=None):
+    def __init__(self, version='v1.0'):
         """Create a mrdb service."""
         super(MrdbService, self).__init__(
             service_type='managed-rdb',

--- a/ecl/managed_rdb/v1/database_version.py
+++ b/ecl/managed_rdb/v1/database_version.py
@@ -17,8 +17,8 @@ from ecl import resource2
 class DatabaseVersion(resource2.Resource):
     resources_key = "database_versions"
     resource_key = "database_versions"
-    base_path = '/database_versions'
     service = mrdb_service.MrdbService()
+    base_path = '/' + service.version + '/database_versions'
 
     # Capabilities
     allow_get = True

--- a/ecl/managed_rdb/v1/flavor.py
+++ b/ecl/managed_rdb/v1/flavor.py
@@ -17,8 +17,8 @@ from ecl import resource2
 class Flavor(resource2.Resource):
     resources_key = "flavors"
     resource_key = "flavor"
-    base_path = '/flavors'
     service = mrdb_service.MrdbService()
+    base_path = '/' + service.version + '/flavors'
 
     # Capabilities
     allow_get = True

--- a/ecl/managed_rdb/v1/instance.py
+++ b/ecl/managed_rdb/v1/instance.py
@@ -104,7 +104,6 @@ class InstanceDetail(Instance):
 class InstanceAction(resource2.Resource):
     service = mrdb_service.MrdbService()
     base_path = '/' + service.version + '/instances/%(instance_id)s/action'
-    service = mrdb_service.MrdbService()
 
     # Properties
     #: Admin password of the mRDB instance.

--- a/ecl/managed_rdb/v1/instance.py
+++ b/ecl/managed_rdb/v1/instance.py
@@ -18,8 +18,8 @@ from ecl import resource2
 class Instance(resource2.Resource):
     resources_key = "instances"
     resource_key = "instance"
-    base_path = '/instances'
     service = mrdb_service.MrdbService()
+    base_path = '/' + service.version + '/instances'
 
     # Capabilities
     allow_get = True
@@ -89,7 +89,8 @@ class Instance(resource2.Resource):
 
 
 class InstanceDetail(Instance):
-    base_path = '/instances/detail'
+    service = mrdb_service.MrdbService()
+    base_path = '/' + service.version + '/instances/detail'
 
     # capabilities
     allow_get = False
@@ -101,7 +102,8 @@ class InstanceDetail(Instance):
 
 
 class InstanceAction(resource2.Resource):
-    base_path = '/instances/%(instance_id)s/action'
+    service = mrdb_service.MrdbService()
+    base_path = '/' + service.version + '/instances/%(instance_id)s/action'
     service = mrdb_service.MrdbService()
 
     # Properties

--- a/ecl/managed_rdb/v1/metadata.py
+++ b/ecl/managed_rdb/v1/metadata.py
@@ -15,8 +15,8 @@ from ecl import resource2
 
 
 class Metadata(resource2.Resource):
-    base_path = '/instances/%(instance_id)s/metadata'
     service = mrdb_service.MrdbService()
+    base_path = '/' + service.version + '/instances/%(instance_id)s/metadata'
 
     # Capabilities
     allow_list = True

--- a/ecl/managed_rdb/v1/quota.py
+++ b/ecl/managed_rdb/v1/quota.py
@@ -16,8 +16,8 @@ from ecl import resource2
 
 class Quota(resource2.Resource):
     resource_key = "quota"
-    base_path = '/quotas'
     service = mrdb_service.MrdbService()
+    base_path = '/' + service.version + '/quotas'
 
     # Capabilities
     allow_get = True

--- a/ecl/managed_rdb/v1/storage_type.py
+++ b/ecl/managed_rdb/v1/storage_type.py
@@ -16,8 +16,8 @@ from ecl import resource2
 
 class StorageType(resource2.Resource):
     resources_key = "storage_types"
-    base_path = '/storage_types'
     service = mrdb_service.MrdbService()
+    base_path = '/' + service.version + '/storage_types'
 
     # Capabilities
     allow_list = True

--- a/ecl/tests/unit/managed_rdb/v1/test_database_version.py
+++ b/ecl/tests/unit/managed_rdb/v1/test_database_version.py
@@ -29,7 +29,7 @@ class TestDatabaseVersion(testtools.TestCase):
         sot = database_version.DatabaseVersion()
         self.assertEqual('database_versions', sot.resources_key)
         self.assertEqual('database_versions', sot.resource_key)
-        self.assertEqual('/database_versions', sot.base_path)
+        self.assertEqual('/v1.0/database_versions', sot.base_path)
         self.assertEqual('managed-rdb', sot.service.service_type)
         self.assertTrue(sot.allow_get)
         self.assertTrue(sot.allow_list)

--- a/ecl/tests/unit/managed_rdb/v1/test_flavor.py
+++ b/ecl/tests/unit/managed_rdb/v1/test_flavor.py
@@ -29,7 +29,7 @@ class TestFlavor(testtools.TestCase):
         sot = flavor.Flavor()
         self.assertEqual('flavors', sot.resources_key)
         self.assertEqual('flavor', sot.resource_key)
-        self.assertEqual('/flavors', sot.base_path)
+        self.assertEqual('/v1.0/flavors', sot.base_path)
         self.assertEqual('managed-rdb', sot.service.service_type)
         self.assertTrue(sot.allow_get)
         self.assertTrue(sot.allow_list)

--- a/ecl/tests/unit/managed_rdb/v1/test_instance.py
+++ b/ecl/tests/unit/managed_rdb/v1/test_instance.py
@@ -81,7 +81,7 @@ class TestInstance(testtools.TestCase):
         sot = instance.Instance()
         self.assertEqual('instances', sot.resources_key)
         self.assertEqual('instance', sot.resource_key)
-        self.assertEqual('/instances', sot.base_path)
+        self.assertEqual('/v1.0/instances', sot.base_path)
         self.assertEqual('managed-rdb', sot.service.service_type)
         self.assertTrue(sot.allow_get)
         self.assertTrue(sot.allow_list)
@@ -110,7 +110,7 @@ class TestInstance(testtools.TestCase):
 
     def test_detail(self):
         sot = instance.InstanceDetail()
-        self.assertEqual('/instances/detail', sot.base_path)
+        self.assertEqual('/v1.0/instances/detail', sot.base_path)
         self.assertEqual('managed-rdb', sot.service.service_type)
         self.assertFalse(sot.allow_get)
         self.assertTrue(sot.allow_list)
@@ -121,7 +121,7 @@ class TestInstance(testtools.TestCase):
 
     def test_action(self):
         sot = instance.InstanceAction()
-        self.assertEqual('/instances/%(instance_id)s/action', sot.base_path)
+        self.assertEqual('/v1.0/instances/%(instance_id)s/action', sot.base_path)
         self.assertEqual('managed-rdb', sot.service.service_type)
 
     def test_make_action(self):

--- a/ecl/tests/unit/managed_rdb/v1/test_metadata.py
+++ b/ecl/tests/unit/managed_rdb/v1/test_metadata.py
@@ -26,7 +26,7 @@ class TestMetadata(testtools.TestCase):
 
     def test_basic(self):
         sot = metadata.Metadata()
-        self.assertEqual('/instances/%(instance_id)s/metadata', sot.base_path)
+        self.assertEqual('/v1.0/instances/%(instance_id)s/metadata', sot.base_path)
         self.assertEqual('managed-rdb', sot.service.service_type)
         self.assertTrue(sot.allow_list)
         self.assertTrue(sot.allow_update)

--- a/ecl/tests/unit/managed_rdb/v1/test_quota.py
+++ b/ecl/tests/unit/managed_rdb/v1/test_quota.py
@@ -24,7 +24,7 @@ class TestQuota(testtools.TestCase):
     def test_basic(self):
         sot = quota.Quota()
         self.assertEqual('quota', sot.resource_key)
-        self.assertEqual('/quotas', sot.base_path)
+        self.assertEqual('/v1.0/quotas', sot.base_path)
         self.assertEqual('managed-rdb', sot.service.service_type)
         self.assertTrue(sot.allow_get)
 

--- a/ecl/tests/unit/managed_rdb/v1/test_storage_type.py
+++ b/ecl/tests/unit/managed_rdb/v1/test_storage_type.py
@@ -27,7 +27,7 @@ class TestStorageType(testtools.TestCase):
     def test_basic(self):
         sot = storage_type.StorageType()
         self.assertEqual('storage_types', sot.resources_key)
-        self.assertEqual('/storage_types', sot.base_path)
+        self.assertEqual('/v1.0/storage_types', sot.base_path)
         self.assertEqual('managed-rdb', sot.service.service_type)
         self.assertTrue(sot.allow_list)
 


### PR DESCRIPTION
* デフォルトのバージョンとして "v1.0"を指定した
  - ecl/managed_rdb/mrdb_service.py
* base_pathの先頭にバージョンを付与した
  - ecl/managed_rdb/v1/database_version.py
  - ecl/managed_rdb/v1/flavor.py
  - ecl/managed_rdb/v1/instance.py
  - ecl/managed_rdb/v1/metadata.py
  - ecl/managed_rdb/v1/quota.py
  - ecl/managed_rdb/v1/storage_type.py
* 単体テストで base_pathと比較する値の先頭にバージョンを付与した
  - ecl/tests/unit/managed_rdb/v1/test_database_version.py
  - ecl/tests/unit/managed_rdb/v1/test_flavor.py
  - ecl/tests/unit/managed_rdb/v1/test_instance.py
  - ecl/tests/unit/managed_rdb/v1/test_metadata.py
  - ecl/tests/unit/managed_rdb/v1/test_quota.py
  - ecl/tests/unit/managed_rdb/v1/test_storage_type.py