### PR TITLE
:sparkles: IF-8657 Fix Exception Message Getting from errorMessage

### DIFF
--- a/ecl/exceptions.py
+++ b/ecl/exceptions.py
@@ -84,7 +84,7 @@ class HttpException(SDKException):
 
             # IAM error case.
             if content.get('errorMessage'):
-                return content[self.api_error_key]
+                return content['errorMessage']
 
             # Function specific case.
             if hasattr(self, 'api_error_key') \

--- a/ecl/managed_rdb/exceptions.py
+++ b/ecl/managed_rdb/exceptions.py
@@ -6,7 +6,19 @@ from ecl import exceptions
 
 
 class HttpException(exceptions.HttpException):
-    pass
+
+    def _get_exception_message(self, message=None):
+        try:
+            content = json.loads(self.response._content.decode('utf-8'))
+
+            # mRDB error case.
+            if content.get('errorCode') and content.get('errorMessage'):
+                return '[' + str(content['errorCode']) + '] ' + content['errorMessage']
+
+        except:
+            pass
+
+        return super()._get_exception_message(message=message)
 
 
 class NotFoundException(HttpException):

--- a/ecl/virtual_network_appliance/exceptions.py
+++ b/ecl/virtual_network_appliance/exceptions.py
@@ -17,7 +17,7 @@ class HttpException(exceptions.HttpException):
 
             # IAM error case.
             if content.get('errorMessage'):
-                return content[self.api_error_key]
+                return content['errorMessage']
 
             # In VNA API, we need to handle both "cause" and "message" key
             # as API error.


### PR DESCRIPTION
* ecl/exceptions.py
  - self.api_error_keyではなく errorMessageキーを参照するよう修正
* ecl/managed_rdb/exceptions.py
  - mRDBの異常系のレスポンスを解析して errorCode, errorMessageを例外メッセージとして返すよう修正
* ecl/virtual_network_appliance/exceptions.py
  - self.api_error_keyではなく errorMessageキーを参照するよう修正