### PR TITLE
:sparkles: Add sss get user service menu API IF-9778

### DIFF
--- a/ecl/sss/v2/_proxy.py
+++ b/ecl/sss/v2/_proxy.py
@@ -17,6 +17,7 @@ from ecl.sss.v2 import channel as _channel
 from ecl.sss.v2 import contract as _contract
 from ecl.sss.v2 import iam_group as _iam_group
 from ecl.sss.v2 import iam_role as _iam_role
+from ecl.sss.v2 import service_menu as _service_menu
 from ecl.sss.v2 import token as _token
 from ecl.sss.v2 import workspace as _workspace
 from ecl import proxy2
@@ -548,6 +549,8 @@ class Proxy(proxy2.BaseProxy):
     def get_user_token_by_admin(self, user_id, tenant_id=None, no_catalog=True):
         """Obtain a user token by SSS on behalf
 
+        Must be run by administrator account.
+
         :param user_id: ID of a user
         :param tenant_id: ID of a tenant
         :param bool no_catalog: Exclude the service catalog from the response.
@@ -558,3 +561,15 @@ class Proxy(proxy2.BaseProxy):
                                              user_id=user_id,
                                              tenant_id=tenant_id,
                                              no_catalog=no_catalog)
+
+    def get_user_service_menu(self, user_id):
+        """Get menu of services available to user.
+
+        Must be run by administrator account.
+
+        :param user_id: ID of a user
+        :return: :class:`~ecl.sss.v2.service_menu.ServiceMenu`
+        """
+        service_menu = _service_menu.ServiceMenu()
+        return service_menu.get_user_service_menu(session=self.session,
+                                                  user_id=user_id)

--- a/ecl/sss/v2/service_menu.py
+++ b/ecl/sss/v2/service_menu.py
@@ -1,0 +1,36 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from ecl import resource2
+from ecl.sss import sss_service
+
+
+class ServiceMenu(resource2.Resource):
+    service = sss_service.SssAdminService()
+
+    # Properties
+    #: User id. format is ecid[0-9]{10}.
+    user_id = resource2.Body('user_id')
+    #: Category information of service menu
+    categories = resource2.Body('categories')
+
+    def get_user_service_menu(self, session, user_id):
+        """Get menu of services available to user.
+
+        :param session: The session to use for making this request.
+        :param user_id: ID of a user
+        :return: :class:`~ecl.sss.v2.service_menu.ServiceMenu`
+        """
+        url = '/users/%s/service-menus' % user_id
+        resp = session.get(url, endpoint_filter=self.service)
+        self._translate_response(resp, has_body=True)
+        return self

--- a/ecl/tests/functional/sss/v2/test_service_menu.py
+++ b/ecl/tests/functional/sss/v2/test_service_menu.py
@@ -1,0 +1,85 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import os
+import unittest
+
+import six
+
+import ecl
+from ecl.tests.functional import base
+
+
+class TestServiceMenu(base.BaseFunctionalTest):
+    """Test ServiceMenu resources
+
+    To run this test, you will need.
+    - Prior Smart Data Platform login
+    - Administrator account
+    """
+    @classmethod
+    def setUpClass(cls):
+        # keystone admin endpoint URL
+        admin_keystone_url = os.getenv('ADMIN_KEYSTONE_URL')
+        # adminstrator account
+        admin_username = os.getenv('ADMIN_USER_NAME')
+        admin_password = os.getenv('ADMIN_PASSWORD')
+        # user information
+        cls.user_ecid = os.getenv('USER_ECID')
+
+        cls.conn = ecl.connection.Connection(auth_url=admin_keystone_url,
+                                             username=admin_username,
+                                             password=admin_password,
+                                             user_domain_id='default',
+                                             timeout=100)
+
+    @unittest.skip("Skip as it requires administrator authorization.")
+    def test_get_user_service_menu(self):
+        service_menu = self.conn.sss.get_user_service_menu(self.user_ecid)
+        self.assertIsInstance(service_menu.user_id, six.string_types)
+        self.assertIsInstance(service_menu.categories, list)
+
+    @unittest.skip("Skip as it requires administrator authorization.")
+    def test_categories_in_service_menu(self):
+        service_menu = self.conn.sss.get_user_service_menu(self.user_ecid)
+        for category in service_menu.categories:
+            self._check_category(category)
+            sub_categories = category.get('sub_categories')
+
+            for sub_category in sub_categories:
+                self._check_sub_category(sub_category)
+                service_menus = sub_category.get('service_menus')
+
+                for service_menu in service_menus:
+                    self._check_service_menu(service_menu)
+
+    def _check_category(self, category):
+        self.assertIsInstance(category, dict)
+        self.assertIsInstance(category.get('category_name'),
+                              six.string_types)
+        self.assertIsInstance(category.get('sub_categories'), list)
+
+    def _check_sub_category(self, sub_category):
+        self.assertIsInstance(sub_category, dict)
+        self.assertIsInstance(sub_category.get('sub_category_name'),
+                              six.string_types)
+        self.assertIsInstance(sub_category.get('service_menus'), list)
+
+    def _check_service_menu(self, service_menu):
+        self.assertIsInstance(service_menu, dict)
+        self.assertIsInstance(service_menu.get('menu_name'), six.string_types)
+        areas = service_menu.get('areas')
+        self.assertIsInstance(areas, list)
+        for area in areas:
+            self.assertIsInstance(area, dict)
+            self.assertIn('area_name', area)
+            self.assertIn('region_name', area)

--- a/ecl/tests/unit/sss/v2/test_service_menu.py
+++ b/ecl/tests/unit/sss/v2/test_service_menu.py
@@ -1,0 +1,66 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import testtools
+
+from ecl.sss.v2 import service_menu
+
+CATEGORIES_EXAMPLE = [
+    {
+        "category_name": "menu.category.test1",
+        "sub_categories": [
+            {
+                "sub_category_name": "menu.subcategory.test1",
+                "service_menus": [
+                    {
+                        "menu_name": "sss.menu.test1",
+                        "areas": [
+                            {"region_name": "lab3ec"},
+                            {"region_name": "lab4ec"},
+                            {"region_name": "lab5ec"}
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+]
+
+USER_SERVICE_MENU_EXAMPLE = {
+    'user_id': 'user1234567890',
+    'categories': CATEGORIES_EXAMPLE
+}
+
+
+class TestServiceMenu(testtools.TestCase):
+
+    def test_service_menu(self):
+        sot = service_menu.ServiceMenu()
+        self.assertEqual(None, sot.resources_key, message='resouces_key')
+        self.assertEqual(None, sot.resource_key, message='resource_key')
+        self.assertEqual('', sot.base_path, message='base_path')
+        self.assertEqual('sssv2', sot.service.service_type,
+                         message='service_type')
+
+        self.assertFalse(sot.allow_create, msg='allow_create')
+        self.assertFalse(sot.allow_get, msg='allow_get')
+        self.assertFalse(sot.allow_update, msg='allow_update')
+        self.assertFalse(sot.allow_delete, msg='allow_delete')
+        self.assertFalse(sot.allow_list, msg='allow_list')
+        self.assertFalse(sot.allow_head, msg='allow_head')
+        self.assertFalse(sot.patch_update, msg='patch_update')
+        self.assertFalse(sot.put_create, msg='put_create')
+
+    def test_make_user_service_menu(self):
+        sot = service_menu.ServiceMenu(**USER_SERVICE_MENU_EXAMPLE)
+        self.assertEqual(USER_SERVICE_MENU_EXAMPLE['user_id'], sot.user_id)
+        self.assertEqual(CATEGORIES_EXAMPLE, sot.categories)


### PR DESCRIPTION
### Overview
Add SSS API (for Admin Endpoint)
- GET users/{user_id}/service-menus

### Detail
- ecl/sss/v2/_proxy.py
    - Added get_user_service_menu(). 
- ecl/sss/v2/service_menu.py
    - Added ServiceMenu resource.
- ecl/tests/unit/sss/v2/test_service_menu.py
    - Added test code.
- ecl/tests/functional/sss/v2/test_service_menu.py
    - Added test code.