### PR TITLE
:sparkles: Add MEC-GW API IF-10332

### DIFF
--- a/ecl/network/v2/_proxy.py
+++ b/ecl/network/v2/_proxy.py
@@ -1491,6 +1491,7 @@ class Proxy(proxy2.BaseProxy):
         :param IPv6 gw_vipv6: gateway virtual IPv6 of gateway interface to create
         :param string interdc_gw_id: InterDC Gateway ID of gateway interface to create
         :param string internet_gw_id: Internet Gateway ID of gateway interface to create
+        :param string mec_gw_id: MEC Gateway ID of gateway interface to create
         :param string vpn_gw_id: VPN Gateway ID of gateway interface to create
         :param string fic_gw_id: FIC Gateway ID of gateway interface to create
         :param string tenant_id: tenant ID of gateway interface to create
@@ -1617,6 +1618,7 @@ class Proxy(proxy2.BaseProxy):
         :param description: description of static route to create
         :param interdc_gw_id: InterDC Gateway ID of static route to create
         :param internet_gw_id: Internet Gateway ID of static route to create
+        :param mec_gw_id: MEC Gateway ID of static route to create
         :param vpn_gw_id: VPN Gateway ID of static route to create
         :param fic_gw_id: FIC Gateway ID of static route to create
         :param tenant_id: tenant ID of static route to create

--- a/ecl/network/v2/_proxy.py
+++ b/ecl/network/v2/_proxy.py
@@ -1472,6 +1472,7 @@ class Proxy(proxy2.BaseProxy):
                                  primary_ipv6=None, secondary_ipv6=None,
                                  gw_vipv6=None, interdc_gw_id=None,
                                  internet_gw_id=None,
+                                 mec_gw_id=None,
                                  vpn_gw_id=None, aws_gw_id=None, gcp_gw_id=None,
                                  azure_gw_id=None, fic_gw_id=None, tenant_id=None):
         """Create a Gateway Interface from parameters
@@ -1520,6 +1521,8 @@ class Proxy(proxy2.BaseProxy):
             body.update({"interdc_gw_id": interdc_gw_id})
         if internet_gw_id:
             body.update({"internet_gw_id": internet_gw_id})
+        if mec_gw_id:
+            body.update({"mec_gw_id": mec_gw_id})
         if vpn_gw_id:
             body.update({"vpn_gw_id": vpn_gw_id})
         if aws_gw_id:
@@ -1603,7 +1606,7 @@ class Proxy(proxy2.BaseProxy):
 
     def create_static_route(self, service_type, destination, nexthop,
                             name=None, description=None,interdc_gw_id=None,
-                            internet_gw_id=None, vpn_gw_id=None, aws_gw_id=None,
+                            internet_gw_id=None, mec_gw_id=None, vpn_gw_id=None, aws_gw_id=None,
                             gcp_gw_id=None, azure_gw_id=None, fic_gw_id=None, tenant_id=None):
         """Create a Static Route
 
@@ -1634,6 +1637,8 @@ class Proxy(proxy2.BaseProxy):
             body.update({"interdc_gw_id": interdc_gw_id})
         if internet_gw_id:
             body.update({"internet_gw_id": internet_gw_id})
+        if mec_gw_id:
+            body.update({"mec_gw_id": mec_gw_id})
         if vpn_gw_id:
             body.update({"vpn_gw_id": vpn_gw_id})
         if aws_gw_id:

--- a/ecl/network/v2/_proxy.py
+++ b/ecl/network/v2/_proxy.py
@@ -36,6 +36,7 @@ from ecl.network.v2 import gcp as _gcp
 from ecl.network.v2 import tenant_connection as _tenant_connection
 from ecl.network.v2 import azure as _azure
 from ecl.network.v2 import fic as _fic
+from ecl.network.v2 import mec as _mec
 
 from ecl import proxy2
 
@@ -2776,3 +2777,81 @@ class Proxy(proxy2.BaseProxy):
                  when no resource can be found.
         """
         return self._get(_fic.FICInterface, fic_interface)
+
+    def mec_services(self, **query):
+        """Return a list of MEC Service
+
+        :returns: A list of MEC Service objects
+        """
+        return list(self._list(_mec.MECService, paginated=False,
+                               **query))
+
+    def get_mec_service(self, mec_service):
+
+        """Get a single MEC Service
+
+        :param mec_service: The value can be the ID of a MEC Service or a
+                       :class:`~ecl.network.v2.mec.MECService` instance.
+
+        :returns: One :class:`~ecl.network.v2.mec.MECService`
+        :raises: :class:`~ecl.exceptions.ResourceNotFound`
+                 when no resource can be found.
+        """
+        return self._get(_mec.MECService, mec_service)
+
+    def mec_gateways(self, **query):
+        """Return a list of MEC Gateways
+
+        :param query: Query parameters to select results
+
+        :returns: A list of MEC Gateway objects
+        """
+        return list(self._list(_mec.MECGateway, paginated=False, **query))
+
+    def get_mec_gateway(self, mec_gateway):
+
+        """Get a single MEC Gateway
+
+        :param mec_gateway: The value can be the ID of a MEC Gateway or a
+                       :class:`~ecl.network.v2.mec.MECGateway` instance.
+
+        :returns: One :class:`~ecl.network.v2.mec.MECGateway`
+        :raises: :class:`~ecl.exceptions.ResourceNotFound`
+                 when no resource can be found.
+        """
+        return self._get(_mec.MECGateway, mec_gateway)
+
+    def find_mec_gateway(self, name_or_id, ignore_missing=False):
+        """Find a single mec_gateway
+
+        :param name_or_id: The name or ID of a mec_gateway.
+        :param bool ignore_missing: When set to ``False``
+                    :class:`~ecl.exceptions.ResourceNotFound` will be
+                    raised when the resource does not exist.
+                    When set to ``True``, None will be returned when
+                    attempting to find a nonexistent resource.
+        :returns: One :class:`~ecl.network.v2.mec.MECGateway` or None
+        """
+        return self._find(_mec.MECGateway,
+                          name_or_id, ignore_missing=ignore_missing)
+
+    def mec_interfaces(self, **query):
+        """Return a list of MEC Interface
+
+        :returns: A list of MEC Interface objects
+        """
+        return list(self._list(_mec.MECInterface, paginated=False,
+                               *query))
+
+    def get_mec_interface(self, mec_interface):
+
+        """Get a single MEC Gateway
+
+        :param mec_interface: The value can be the ID of a MEC Interface or a
+                       :class:`~ecl.network.v2.mec.MECInterface` instance.
+
+        :returns: One :class:`~ecl.network.v2.mec.MECInterface`
+        :raises: :class:`~ecl.exceptions.ResourceNotFound`
+                 when no resource can be found.
+        """
+        return self._get(_mec.MECInterface, mec_interface)

--- a/ecl/network/v2/gw_interface.py
+++ b/ecl/network/v2/gw_interface.py
@@ -17,6 +17,7 @@ class GatewayInterface(NetworkBaseResource):
     _query_mapping = resource2.QueryParameters(
         "description", "gw_vipv4", "gw_vipv6",
         "id", "interdc_gw_id", "internet_gw_id",
+        "mec_gw_id",
         "name", "netmask", "network_id",
         "primary_ipv4", "primary_ipv6",
         "secondary_ipv4", "secondary_ipv6",
@@ -38,6 +39,7 @@ class GatewayInterface(NetworkBaseResource):
     id = resource2.Body("id")
     interdc_gw_id = resource2.Body("interdc_gw_id")
     internet_gw_id = resource2.Body("internet_gw_id")
+    mec_gw_id = resource2.Body("mec_gw_id")
     name = resource2.Body("name")
     netmask = resource2.Body("netmask")
     network_id = resource2.Body("network_id")

--- a/ecl/network/v2/mec.py
+++ b/ecl/network/v2/mec.py
@@ -19,7 +19,6 @@ class MECService(NetworkBaseResource):
     _query_mapping = resource2.QueryParameters(
         "description", "id",
         "name", "zone",
-        "tenant_id",
     )
 
     description = resource2.Body("description")

--- a/ecl/network/v2/mec.py
+++ b/ecl/network/v2/mec.py
@@ -1,14 +1,13 @@
 # -*- coding: utf-8 -*-
 
 
+from ecl import exceptions
+from ecl import resource2
 from ecl.network import network_service
 from ecl.network.v2.base import NetworkBaseResource
-from ecl import resource2
-from ecl import exceptions
 
 
 class MECService(NetworkBaseResource):
-
     resource_key = "mec_service"
     resources_key = "mec_services"
     service = network_service.NetworkService("v2.0")
@@ -20,17 +19,17 @@ class MECService(NetworkBaseResource):
     _query_mapping = resource2.QueryParameters(
         "description", "id",
         "name", "zone",
-        "sort_key", "sort_dir",
+        "tenant_id",
     )
 
     description = resource2.Body("description")
     id = resource2.Body("id")
     zone = resource2.Body("zone")
     name = resource2.Body("name")
+    tenant_id = resource2.Body("tenant_id")
 
 
 class MECGateway(NetworkBaseResource):
-
     resource_key = "mec_gateway"
     resources_key = "mec_gateways"
     service = network_service.NetworkService("v2.0")
@@ -38,16 +37,12 @@ class MECGateway(NetworkBaseResource):
 
     allow_list = True
     allow_get = True
-    allow_create = True
-    allow_update = True
-    allow_delete = True
 
     _query_mapping = resource2.QueryParameters(
         "description", "id",
         "name", "qos_option_id",
         "status", "tenant_id",
         "mec_service_id",
-        "sort_key", "sort_dir",
     )
 
     description = resource2.Body("description")
@@ -98,7 +93,6 @@ class MECGateway(NetworkBaseResource):
 
 
 class MECInterface(NetworkBaseResource):
-
     resource_key = "mec_interface"
     resources_key = "mec_interfaces"
     service = network_service.NetworkService("v2.0")
@@ -106,15 +100,11 @@ class MECInterface(NetworkBaseResource):
 
     allow_list = True
     allow_get = True
-    allow_create = True
-    allow_update = True
-    allow_delete = True
 
     _query_mapping = resource2.QueryParameters(
         "description", "id",
         "name", "mec_gw_id",
         "status", "tenant_id",
-        "sort_key", "sort_dir",
     )
 
     description = resource2.Body("description")

--- a/ecl/network/v2/mec.py
+++ b/ecl/network/v2/mec.py
@@ -1,0 +1,132 @@
+# -*- coding: utf-8 -*-
+
+
+from ecl.network import network_service
+from ecl.network.v2.base import NetworkBaseResource
+from ecl import resource2
+from ecl import exceptions
+
+
+class MECService(NetworkBaseResource):
+
+    resource_key = "mec_service"
+    resources_key = "mec_services"
+    service = network_service.NetworkService("v2.0")
+    base_path = '/' + service.version + '/mec_services'
+
+    allow_list = True
+    allow_get = True
+
+    _query_mapping = resource2.QueryParameters(
+        "description", "id",
+        "name", "zone",
+        "sort_key", "sort_dir",
+    )
+
+    description = resource2.Body("description")
+    id = resource2.Body("id")
+    zone = resource2.Body("zone")
+    name = resource2.Body("name")
+
+
+class MECGateway(NetworkBaseResource):
+
+    resource_key = "mec_gateway"
+    resources_key = "mec_gateways"
+    service = network_service.NetworkService("v2.0")
+    base_path = '/' + service.version + '/mec_gateways'
+
+    allow_list = True
+    allow_get = True
+    allow_create = True
+    allow_update = True
+    allow_delete = True
+
+    _query_mapping = resource2.QueryParameters(
+        "description", "id",
+        "name", "qos_option_id",
+        "status", "tenant_id",
+        "mec_service_id",
+        "sort_key", "sort_dir",
+    )
+
+    description = resource2.Body("description")
+    id = resource2.Body("id")
+    name = resource2.Body("name")
+    qos_option_id = resource2.Body("qos_option_id")
+    status = resource2.Body("status")
+    tenant_id = resource2.Body("tenant_id")
+    mec_service_id = resource2.Body("mec_service_id")
+
+    @classmethod
+    def find(cls, session, name_or_id, ignore_missing=False, **params):
+        """Find a resource by its name or id.
+
+        :param session: The session to use for making this request.
+        :type session: :class:`~ecl.session.Session`
+        :param name_or_id: This resource's identifier, if needed by
+                           the request. The default is ``None``.
+        :param bool ignore_missing: When set to ``False``
+                    :class:`~ecl.exceptions.ResourceNotFound` will be
+                    raised when the resource does not exist.
+                    When set to ``True``, None will be returned when
+                    attempting to find a nonexistent resource.
+        :param dict params: Any additional parameters to be passed into
+                            underlying methods, such as to
+                            :meth:`~ecl.resource2.Resource.existing`
+                            in order to pass on URI parameters.
+
+        :return: The :class:`Resource` object matching the given name or id
+                 or None if nothing matches.
+        :raises: :class:`ecl.exceptions.DuplicateResource` if more
+                 than one resource is found for this request.
+        :raises: :class:`ecl.exceptions.ResourceNotFound` if nothing
+                 is found and ignore_missing is ``False``.
+        """
+        # Try to short-circuit by looking directly for a matching ID.
+
+        data = cls.list(session, **params)
+
+        result = cls._get_one_match(name_or_id, data)
+        if result is not None:
+            return result
+
+        if ignore_missing:
+            return None
+        raise exceptions.ResourceNotFound(
+            "No %s found for %s" % (cls.__name__, name_or_id))
+
+
+class MECInterface(NetworkBaseResource):
+
+    resource_key = "mec_interface"
+    resources_key = "mec_interfaces"
+    service = network_service.NetworkService("v2.0")
+    base_path = '/' + service.version + '/mec_interfaces'
+
+    allow_list = True
+    allow_get = True
+    allow_create = True
+    allow_update = True
+    allow_delete = True
+
+    _query_mapping = resource2.QueryParameters(
+        "description", "id",
+        "name", "mec_gw_id",
+        "status", "tenant_id",
+        "sort_key", "sort_dir",
+    )
+
+    description = resource2.Body("description")
+    id = resource2.Body("id")
+    mec_gw_id = resource2.Body("mec_gw_id")
+    name = resource2.Body("name")
+    status = resource2.Body("status")
+    tenant_id = resource2.Body("tenant_id")
+    primary = resource2.Body("primary")
+    secondary = resource2.Body("secondary")
+
+    def wait_for_interface(self, session, status='ACTIVE', failures=['ERROR'],
+                           interval=2, wait=120):
+        return resource2.wait_for_status(session, self, status,
+                                         failures, interval, wait)

--- a/ecl/network/v2/qos_option.py
+++ b/ecl/network/v2/qos_option.py
@@ -19,7 +19,7 @@ class QosOption(NetworkBaseResource):
 
     _query_mapping = resource2.QueryParameters(
         "description", "bandwidth", "name",
-        "status", "qos_type","mec_service_id",
+        "status", "qos_type", "mec_service_id",
         "service_type",
         "interdc_service_id", "internet_service_id",
         "vpn_service_id", "sort_key", "sort_dir",

--- a/ecl/network/v2/qos_option.py
+++ b/ecl/network/v2/qos_option.py
@@ -19,7 +19,8 @@ class QosOption(NetworkBaseResource):
 
     _query_mapping = resource2.QueryParameters(
         "description", "bandwidth", "name",
-        "status", "qos_type", "service_type",
+        "status", "qos_type","mec_service_id",
+        "service_type",
         "interdc_service_id", "internet_service_id",
         "vpn_service_id", "sort_key", "sort_dir",
         "fic_service_id",
@@ -31,6 +32,7 @@ class QosOption(NetworkBaseResource):
     name = resource2.Body("name")
     status = resource2.Body("status")
     qos_type = resource2.Body("qos_type")
+    mec_service_id = resource2.Body("mec_service_id")
     service_type = resource2.Body("service_type")
     interdc_service_id = resource2.Body("interdc_service_id")
     internet_service_id = resource2.Body("internet_service_id")

--- a/ecl/network/v2/quota.py
+++ b/ecl/network/v2/quota.py
@@ -23,6 +23,8 @@ class Quota(resource2.Resource):
     common_function_gateway = resource2.Body('common_function_gateway', type=int)
     #: The maximum amount of fic gateway you can create. *Type: int*
     fic_gateway = resource2.Body('fic_gateway', type=int)
+    #: The maximum amount of mec gateway you can create. *Type: int*
+    mec_gateway = resource2.Body('mec_gateway', type=int)
     #: The maximum amount of firewall you can create. *Type: int*
     firewall = resource2.Body('firewall', type=int)
     #: ID of quota

--- a/ecl/network/v2/static_route.py
+++ b/ecl/network/v2/static_route.py
@@ -22,6 +22,7 @@ class StaticRoute(NetworkBaseResource):
     _query_mapping = resource2.QueryParameters(
         "description", "id", "destination",
         "name", "interdc_gw_id", "internet_gw_id",
+        "mec_gw_id",
         "nexthop", "service_type", "status", "tenant_id",
         "vpn_gw_id", "sort_key", "sort_dir", "aws_gw_id",
         "azure_gw_id", "gcp_gw_id", "fic_gw_id",
@@ -32,6 +33,7 @@ class StaticRoute(NetworkBaseResource):
     id = resource2.Body("id")
     interdc_gw_id = resource2.Body("interdc_gw_id")
     internet_gw_id = resource2.Body("internet_gw_id")
+    mec_gw_id = resource2.Body("mec_gw_id")
     name = resource2.Body("name")
     nexthop = resource2.Body("nexthop")
     service_type = resource2.Body("service_type")

--- a/ecl/tests/unit/network/v2/test_mec_gateway.py
+++ b/ecl/tests/unit/network/v2/test_mec_gateway.py
@@ -1,0 +1,51 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import testtools
+
+from ecl.network.v2 import mec
+
+IDENTIFIER = 'IDENTIFIER'
+EXAMPLE = {
+    "description": "Example port 1 description.",
+    "id": "id12345678900",
+    "name": "Example port 1",
+    "qos_option_id": "qosid12345678",
+    "tenant_id": IDENTIFIER,
+    "status": "ACTIVE",
+    "mec_service_id": "mecsid12345678",
+}
+
+
+class TestPort(testtools.TestCase):
+
+    def test_basic(self):
+        sot = mec.MECGateway()
+        self.assertEqual('mec_gateway', sot.resource_key)
+        self.assertEqual('mec_gateways', sot.resources_key)
+        self.assertEqual('/v2.0/mec_gateways', sot.base_path)
+        self.assertEqual('network', sot.service.service_type)
+        self.assertTrue(sot.allow_create)
+        self.assertTrue(sot.allow_get)
+        self.assertTrue(sot.allow_update)
+        self.assertTrue(sot.allow_delete)
+        self.assertTrue(sot.allow_list)
+
+    def test_make_it(self):
+        sot = mec.MECGateway(**EXAMPLE)
+        self.assertEqual(EXAMPLE['description'], sot.description)
+        self.assertEqual(EXAMPLE['id'], sot.id)
+        self.assertEqual(EXAMPLE['name'], sot.name)
+        self.assertEqual(EXAMPLE['qos_option_id'], sot.qos_option_id)
+        self.assertEqual(EXAMPLE['status'], sot.status)
+        self.assertEqual(EXAMPLE['tenant_id'], sot.tenant_id)
+        self.assertEqual(EXAMPLE['mec_service_id'], sot.mec_service_id)

--- a/ecl/tests/unit/network/v2/test_mec_gateway.py
+++ b/ecl/tests/unit/network/v2/test_mec_gateway.py
@@ -14,13 +14,12 @@ import testtools
 
 from ecl.network.v2 import mec
 
-IDENTIFIER = 'IDENTIFIER'
 EXAMPLE = {
-    "description": "Example port 1 description.",
+    "description": "Example gateway 1 description.",
     "id": "id12345678900",
     "name": "Example port 1",
     "qos_option_id": "qosid12345678",
-    "tenant_id": IDENTIFIER,
+    "tenant_id": "IDENTIFIER",
     "status": "ACTIVE",
     "mec_service_id": "mecsid12345678",
 }
@@ -34,10 +33,7 @@ class TestPort(testtools.TestCase):
         self.assertEqual('mec_gateways', sot.resources_key)
         self.assertEqual('/v2.0/mec_gateways', sot.base_path)
         self.assertEqual('network', sot.service.service_type)
-        self.assertTrue(sot.allow_create)
         self.assertTrue(sot.allow_get)
-        self.assertTrue(sot.allow_update)
-        self.assertTrue(sot.allow_delete)
         self.assertTrue(sot.allow_list)
 
     def test_make_it(self):

--- a/ecl/tests/unit/network/v2/test_mec_interface.py
+++ b/ecl/tests/unit/network/v2/test_mec_interface.py
@@ -1,0 +1,53 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import testtools
+
+from ecl.network.v2 import mec
+
+IDENTIFIER = 'IDENTIFIER'
+EXAMPLE = {
+    "description": "Example port 1 description.",
+    "id": "id12345678900",
+    "mec_gw_id": "mecgid12345678",
+    "name": "Example port 1",
+    "status": "ACTIVE",
+    "tenant_id": IDENTIFIER,
+    "primary": "pid1234567890",
+    "secondary": "sid1234567890",
+}
+
+
+class TestPort(testtools.TestCase):
+
+    def test_basic(self):
+        sot = mec.MECInterface()
+        self.assertEqual('mec_interface', sot.resource_key)
+        self.assertEqual('mec_interfaces', sot.resources_key)
+        self.assertEqual('/v2.0/mec_interfaces', sot.base_path)
+        self.assertEqual('network', sot.service.service_type)
+        self.assertTrue(sot.allow_create)
+        self.assertTrue(sot.allow_get)
+        self.assertTrue(sot.allow_update)
+        self.assertTrue(sot.allow_delete)
+        self.assertTrue(sot.allow_list)
+
+    def test_make_it(self):
+        sot = mec.MECInterface(**EXAMPLE)
+        self.assertEqual(EXAMPLE['description'], sot.description)
+        self.assertEqual(EXAMPLE['id'], sot.id)
+        self.assertEqual(EXAMPLE['mec_gw_id'], sot.mec_gw_id)
+        self.assertEqual(EXAMPLE['name'], sot.name)
+        self.assertEqual(EXAMPLE['status'], sot.status)
+        self.assertEqual(EXAMPLE['tenant_id'], sot.tenant_id)
+        self.assertEqual(EXAMPLE['primary'], sot.primary)
+        self.assertEqual(EXAMPLE['secondary'], sot.secondary)

--- a/ecl/tests/unit/network/v2/test_mec_interface.py
+++ b/ecl/tests/unit/network/v2/test_mec_interface.py
@@ -14,16 +14,23 @@ import testtools
 
 from ecl.network.v2 import mec
 
-IDENTIFIER = 'IDENTIFIER'
 EXAMPLE = {
-    "description": "Example port 1 description.",
+    "description": "Example interface 1 description.",
     "id": "id12345678900",
     "mec_gw_id": "mecgid12345678",
     "name": "Example port 1",
     "status": "ACTIVE",
-    "tenant_id": IDENTIFIER,
-    "primary": "pid1234567890",
-    "secondary": "sid1234567890",
+    "tenant_id": "IDENTIFIER",
+    "primary": {
+        "bgp_peer_ip": "192.168.1.11",
+        "bgp_router_id": "192.168.1.12",
+        "ip_address": "192.168.1.1/24",
+    },
+    "secondary": {
+        "bgp_peer_ip": "192.168.1.11",
+        "bgp_router_id": "192.168.1.12",
+        "ip_address": "192.168.1.1/24",
+    },
 }
 
 
@@ -35,10 +42,7 @@ class TestPort(testtools.TestCase):
         self.assertEqual('mec_interfaces', sot.resources_key)
         self.assertEqual('/v2.0/mec_interfaces', sot.base_path)
         self.assertEqual('network', sot.service.service_type)
-        self.assertTrue(sot.allow_create)
         self.assertTrue(sot.allow_get)
-        self.assertTrue(sot.allow_update)
-        self.assertTrue(sot.allow_delete)
         self.assertTrue(sot.allow_list)
 
     def test_make_it(self):

--- a/ecl/tests/unit/network/v2/test_mec_service.py
+++ b/ecl/tests/unit/network/v2/test_mec_service.py
@@ -1,0 +1,43 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import testtools
+
+from ecl.network.v2 import mec
+
+IDENTIFIER = 'IDENTIFIER'
+EXAMPLE = {
+    "description": "Example port 1 description.",
+    "id": "id12345678900",
+    "name": "Example port 1",
+    "tenant_id": IDENTIFIER,
+    "zone": "Name",
+}
+
+
+class TestPort(testtools.TestCase):
+
+    def test_basic(self):
+        sot = mec.MECService()
+        self.assertEqual('mec_service', sot.resource_key)
+        self.assertEqual('mec_services', sot.resources_key)
+        self.assertEqual('/v2.0/mec_services', sot.base_path)
+        self.assertEqual('network', sot.service.service_type)
+        self.assertTrue(sot.allow_get)
+        self.assertTrue(sot.allow_list)
+
+    def test_make_it(self):
+        sot = mec.MECService(**EXAMPLE)
+        self.assertEqual(EXAMPLE['description'], sot.description)
+        self.assertEqual(EXAMPLE['id'], sot.id)
+        self.assertEqual(EXAMPLE['name'], sot.name)
+        self.assertEqual(EXAMPLE['zone'], sot.zone)

--- a/ecl/tests/unit/network/v2/test_mec_service.py
+++ b/ecl/tests/unit/network/v2/test_mec_service.py
@@ -14,12 +14,11 @@ import testtools
 
 from ecl.network.v2 import mec
 
-IDENTIFIER = 'IDENTIFIER'
 EXAMPLE = {
-    "description": "Example port 1 description.",
+    "description": "Example service 1 description.",
     "id": "id12345678900",
     "name": "Example port 1",
-    "tenant_id": IDENTIFIER,
+    "tenant_id": "IDENTIFIER",
     "zone": "Name",
 }
 
@@ -41,3 +40,4 @@ class TestPort(testtools.TestCase):
         self.assertEqual(EXAMPLE['id'], sot.id)
         self.assertEqual(EXAMPLE['name'], sot.name)
         self.assertEqual(EXAMPLE['zone'], sot.zone)
+        self.assertEqual(EXAMPLE['tenant_id'], sot.tenant_id)

--- a/ecl/tests/unit/network/v2/test_quota.py
+++ b/ecl/tests/unit/network/v2/test_quota.py
@@ -28,12 +28,9 @@ EXAMPLE = {
     "subnet": 5,
     "tenant_id": IDENTIFIER,
     "vpn_gateway": 1,
-<<<<<<< HEAD
-    "security_group": 1
-=======
+    "security_group": 1,
     "fic_gateway": 1,
     "mec_gateway": 1
->>>>>>> 76f2ac9 (:sparkles: IF-10332 Fix with comments of the Pull Request)
 }
 
 
@@ -65,12 +62,9 @@ class TestQuota(testtools.TestCase):
         self.assertEqual(EXAMPLE['subnet'], sot.subnet)
         self.assertEqual(EXAMPLE['tenant_id'], sot.project_id)
         self.assertEqual(EXAMPLE['vpn_gateway'], sot.vpn_gateway)
-<<<<<<< HEAD
         self.assertEqual(EXAMPLE['security_group'], sot.security_group)
-=======
         self.assertEqual(EXAMPLE['fic_gateway'], sot.fic_gateway)
         self.assertEqual(EXAMPLE['mec_gateway'], sot.mec_gateway)
->>>>>>> 76f2ac9 (:sparkles: IF-10332 Fix with comments of the Pull Request)
 
 class TestQuotaDefault(testtools.TestCase):
 

--- a/ecl/tests/unit/network/v2/test_quota.py
+++ b/ecl/tests/unit/network/v2/test_quota.py
@@ -28,7 +28,12 @@ EXAMPLE = {
     "subnet": 5,
     "tenant_id": IDENTIFIER,
     "vpn_gateway": 1,
+<<<<<<< HEAD
     "security_group": 1
+=======
+    "fic_gateway": 1,
+    "mec_gateway": 1
+>>>>>>> 76f2ac9 (:sparkles: IF-10332 Fix with comments of the Pull Request)
 }
 
 
@@ -60,7 +65,12 @@ class TestQuota(testtools.TestCase):
         self.assertEqual(EXAMPLE['subnet'], sot.subnet)
         self.assertEqual(EXAMPLE['tenant_id'], sot.project_id)
         self.assertEqual(EXAMPLE['vpn_gateway'], sot.vpn_gateway)
+<<<<<<< HEAD
         self.assertEqual(EXAMPLE['security_group'], sot.security_group)
+=======
+        self.assertEqual(EXAMPLE['fic_gateway'], sot.fic_gateway)
+        self.assertEqual(EXAMPLE['mec_gateway'], sot.mec_gateway)
+>>>>>>> 76f2ac9 (:sparkles: IF-10332 Fix with comments of the Pull Request)
 
 class TestQuotaDefault(testtools.TestCase):
 
@@ -91,3 +101,5 @@ class TestQuotaDefault(testtools.TestCase):
         self.assertEqual(EXAMPLE['tenant_id'], default.project_id)
         self.assertEqual(EXAMPLE['vpn_gateway'], default.vpn_gateway)
         self.assertEqual(EXAMPLE['security_group'], default.security_group)
+        self.assertEqual(EXAMPLE['fic_gateway'], default.fic_gateway)
+        self.assertEqual(EXAMPLE['mec_gateway'], default.mec_gateway)


### PR DESCRIPTION
### Overview
- Creation of new MEC-GW and associated modification of existing code

### Detail
* Support MEC-GW
  - ecl/network/v2/_proxy.py
  - ecl/network/v2/mec.py
* Add parameters
  - ecl/network/v2/gw_interface.py
    - Add `mec_gw_id`
  - ecl/network/v2/qos_option.py
    - Add `mec_service_id`
  - ecl/network/v2/quota.py
    - Add `mec_gateway`
  - ecl/network/v2/static_route.py
    - Add `mec_gw_id`
* For unit test
  - ecl/tests/unit/network/v2/test_mec_gateway.py
  - ecl/tests/unit/network/v2/test_mec_interface.py
  - ecl/tests/unit/network/v2/test_mec_service.py
  - ecl/tests/unit/network/v2/test_quota.py