### PR TITLE
:sparkles: Remove unnecessary parameter for creation of Tenant Connection Request IF-13632

### DIFF
--- a/ecl/provider_connectivity/v1/_proxy.py
+++ b/ecl/provider_connectivity/v1/_proxy.py
@@ -163,15 +163,12 @@ class Proxy(proxy2.BaseProxy):
         return list(self._list(
             _tc_request.TenantConnectionRequest, paginated=False, **query))
 
-    def create_tenant_connection_request(self, keystone_user_id,
-                                         tenant_id_other, tenant_id,
+    def create_tenant_connection_request(self,
+                                         tenant_id_other,
                                          network_id, **params):
         """Create a tenant_connection_request resource.
 
-        :param keystone_user_id: Keystone User ID who can access to the
-                        owner tenant of tenant_connection_request
         :param tenant_id_other: The owner tenant of network
-        :param tenant_id: The owner tenant of tenant_connection_request
         :param network_id: Network unique id
         :param params:
                 name: Name of tenant_connection_request.
@@ -191,10 +188,6 @@ class Proxy(proxy2.BaseProxy):
             body["description"] = params.get("description")
         if params.get("tags"):
             body["tags"] = params.get("tags")
-        if params.get("keystone_user_id"):
-            body["keystone_user_id"] = params.get("keystone_user_id")
-        if params.get("tenant_id"):
-            body["tenant_id"] = params.get("tenant_id")
         return self._create(_tc_request.TenantConnectionRequest, **body)
 
     def update_tenant_connection_request(self, tenant_connection_request,

--- a/ecl/provider_connectivity/v1/tenant_connection_request.py
+++ b/ecl/provider_connectivity/v1/tenant_connection_request.py
@@ -28,7 +28,6 @@ class TenantConnectionRequest(ProviderConnectivityBaseResource):
         'tenant_id_other',
         'network_id',
         'approval_request_id',
-        'keystone_user_id',
     )
 
     #: tenant_connection_request unique ID.
@@ -48,10 +47,6 @@ class TenantConnectionRequest(ProviderConnectivityBaseResource):
 
     #: Tags
     tags = resource2.Body('tags')
-
-    #: Keystone User ID who can access to the owner tenant of
-    # tenant_connection_request.
-    keystone_user_id = resource2.Body('keystone_user_id')
 
     #: Tenant ID of the owner.
     tenant_id = resource2.Body('tenant_id')

--- a/ecl/provider_connectivity/v2/_proxy.py
+++ b/ecl/provider_connectivity/v2/_proxy.py
@@ -164,15 +164,12 @@ class Proxy(proxy2.BaseProxy):
         return list(self._list(
             _tc_request.TenantConnectionRequest, paginated=False, **query))
 
-    def create_tenant_connection_request(self, keystone_user_id,
-                                         tenant_id_other, tenant_id,
+    def create_tenant_connection_request(self,
+                                         tenant_id_other,
                                          network_id, **params):
         """Create a tenant_connection_request resource.
 
-        :param keystone_user_id: Keystone User ID who can access to the
-                        owner tenant of tenant_connection_request
         :param tenant_id_other: The owner tenant of network
-        :param tenant_id: The owner tenant of tenant_connection_request
         :param network_id: Network unique id
         :param params:
                 name: Name of tenant_connection_request.
@@ -192,10 +189,6 @@ class Proxy(proxy2.BaseProxy):
             body["description"] = params.get("description")
         if params.get("tags"):
             body["tags"] = params.get("tags")
-        if params.get("keystone_user_id"):
-            body["keystone_user_id"] = params.get("keystone_user_id")
-        if params.get("tenant_id"):
-            body["tenant_id"] = params.get("tenant_id")
         return self._create(_tc_request.TenantConnectionRequest, **body)
 
     def update_tenant_connection_request(self, tenant_connection_request,

--- a/ecl/provider_connectivity/v2/tenant_connection_request.py
+++ b/ecl/provider_connectivity/v2/tenant_connection_request.py
@@ -28,7 +28,6 @@ class TenantConnectionRequest(ProviderConnectivityBaseResource):
         'tenant_id_other',
         'network_id',
         'approval_request_id',
-        'keystone_user_id',
     )
 
     #: tenant_connection_request unique ID.
@@ -48,10 +47,6 @@ class TenantConnectionRequest(ProviderConnectivityBaseResource):
 
     #: Tags
     tags = resource2.Body('tags')
-
-    #: Keystone User ID who can access to the owner tenant of
-    # tenant_connection_request.
-    keystone_user_id = resource2.Body('keystone_user_id')
 
     #: Tenant ID of the owner.
     tenant_id = resource2.Body('tenant_id')

--- a/ecl/tests/unit/provider_connectivity/v1/test_proxy.py
+++ b/ecl/tests/unit/provider_connectivity/v1/test_proxy.py
@@ -26,14 +26,10 @@ class TestTenantConnectionProxy(test_proxy_base2.TestProxyBase):
         self.verify_create(self.proxy.create_tenant_connection_request,
                            _tc_request.TenantConnectionRequest,
                            method_kwargs={
-                               "keystone_user_id": "test_id",
                                "tenant_id_other": "tenant_id_other",
-                               "tenant_id": "tenant_id",
                                "network_id": "network_id"},
                            expected_kwargs={
-                               "keystone_user_id": "test_id",
                                "tenant_id_other": "tenant_id_other",
-                               "tenant_id": "tenant_id",
                                "network_id": "network_id"})
 
     def test_tenant_connection_request_delete(self):

--- a/ecl/tests/unit/provider_connectivity/v1/test_tenant_connection_request.py
+++ b/ecl/tests/unit/provider_connectivity/v1/test_tenant_connection_request.py
@@ -18,8 +18,7 @@ BASIC_EXAMPLE = {
     'tags_other': 'tags_other',
     'tenant_id_other': 'tenant_id_other',
     'network_id': 'network_id',
-    'keystone_user_id': 'keystone_user_id',
-    'apporoval_request_id': 'apporoval_request_id',
+    'approval_request_id': 'approval_request_id',
     'status': 'status'
 }
 
@@ -50,6 +49,5 @@ class TestTenantConnection(testtools.TestCase):
         self.assertEqual(BASIC_EXAMPLE['tenant_id'], sot.tenant_id)
         self.assertEqual(BASIC_EXAMPLE['tenant_id_other'], sot.tenant_id_other)
         self.assertEqual(BASIC_EXAMPLE['network_id'], sot.network_id)
-        self.assertEqual(BASIC_EXAMPLE['keystone_user_id'], sot.keystone_user_id)
-        self.assertEqual(BASIC_EXAMPLE['apporoval_request_id'], sot.apporoval_request_id)
+        self.assertEqual(BASIC_EXAMPLE['approval_request_id'], sot.approval_request_id)
         self.assertEqual(BASIC_EXAMPLE['status'], sot.status)


### PR DESCRIPTION
### Overview
* Remove unnecessary parameters from creation of tenant connection request

### Detail
- ecl/provider_connectivity/v1/_proxy.py
  - Remove tenant_id, keystone_user_id from function of creation of tenant connection request
- ecl/provider_connectivity/v1/tenant_connection_request.py
  - Remove keystone_user_id from class of tenant connection request
- ecl/provider_connectivity/v2/_proxy.py
  - Remove tenant_id, keystone_user_id from function of creation of tenant connection request
- ecl/provider_connectivity/v2/tenant_connection_request.py
  - Remove keystone_user_id from class of tenant connection request
- ecl/tests/unit/provider_connectivity/v1/test_proxy.py
  - Remove tenant_id, keystone_user_id from test code
- ecl/tests/unit/provider_connectivity/v1/test_tenant_connection_request.py
  - Remove keystone_user_id from test code
  - fix typo `apporoval_request_id` -> `approval_request_id`

