### PR TITLE
:bug: Add a top level key for request parameters IF-14840

### DIFF
--- a/ecl/dedicated_hypervisor/v1/_proxy.py
+++ b/ecl/dedicated_hypervisor/v1/_proxy.py
@@ -288,8 +288,8 @@ class Proxy(proxy2.BaseProxy):
         :return: One :class:`~ecl.dedicated_hypervisor.v1.vcenter.VCenter`
         instance.
         """
-
-        return _vcenter.VCenter.register(self.session, password, license_id)
+        vcenter = _vcenter.VCenter()
+        return vcenter.register(self.session, password, license_id)
 
     def update_vcenter(self, vcenter_id, password=None, license_id=None):
         """
@@ -303,8 +303,8 @@ class Proxy(proxy2.BaseProxy):
         :return: One :class:`~ecl.dedicated_hypervisor.v1.vcenter.VCenter`
         instance.
         """
-
-        return _vcenter.VCenter.update(self.session, vcenter_id, password, license_id)
+        vcenter = _vcenter.VCenter()
+        return vcenter.update(self.session, vcenter_id, password, license_id)
 
     def delete_vcenter(self, vcenter_id, ignore_missing=False):
         """

--- a/ecl/dedicated_hypervisor/v1/vcenter.py
+++ b/ecl/dedicated_hypervisor/v1/vcenter.py
@@ -41,9 +41,15 @@ class VCenter(resource2.Resource):
     instance_name = resource2.Body('instance_name')
 
     def register(self, session, password, license_id):
-        resp = session.post(self.base_path, endpoint_filter = self.service,
-                            json={"password": password,
-                                  "licence_id": license_id})
+        params = {
+            "password": password,
+            "license_id": license_id
+        }
+        resp = session.post(
+            self.base_path,
+            endpoint_filter = self.service,
+            json={self.resource_key: params}
+        )
         self._translate_response(resp, has_body=True)
         return self
 
@@ -58,7 +64,7 @@ class VCenter(resource2.Resource):
         resp = session.put(
             uri,
             endpoint_filter=self.service,
-            json=params
+            json={self.resource_key: params}
         )
         self._translate_response(resp, has_body=True)
         return self


### PR DESCRIPTION
### Overview
* Add a top level key for request parameters.
* Fix to call register, update methods after creating instance.

### Detail
- ecl/dedicated_hypervisor/v1/_proxy.py
  - Add a top level key for request parameters.
- ecl/dedicated_hypervisor/v1/vcenter.py
  - Fix to call register, update methods after creating instance.