### PR TITLE
:sparkles: Python3.5.10 support IF-14956

### DIFF
--- a/ecl/session.py
+++ b/ecl/session.py
@@ -364,12 +364,16 @@ class Session(_session.Session):
         return content
 
     def _send_request(self, url, method, redirect, log, logger,
-                      connect_retries, connect_retry_delay=0.5, **kwargs):
+                      split_loggers, connect_retries, status_code_retries,
+                      retriable_status_codes, connect_retry_delay=0.5,
+                      status_code_retry_delay=0.5, ** kwargs):
+
         resp = super(Session, self)._send_request(
-            url, method, redirect, log,
-            logger, connect_retries,
-            connect_retry_delay=connect_retry_delay,
-            **kwargs)
+            url, method, redirect, log, logger,
+            split_loggers, connect_retries, status_code_retries,
+            retriable_status_codes, connect_retry_delay,
+            status_code_retry_delay, **kwargs)
+
         if re.match('https:', url):
             try:
                 resp._content = self._replace_discoverd_keystone_url(

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ pbr>=1.6 # Apache-2.0
 six>=1.9.0 # MIT
 stevedore>=1.16.0 # Apache-2.0
 os-client-config!=1.19.0,>=1.13.1 # Apache-2.0
-keystoneauth1<=3.4.0,>=2.10.0 # Apache-2.0
-openstacksdk<=0.13.0 # Apache-2.0
+keystoneauth1<=3.8.0,>=2.10.0 # Apache-2.0
+openstacksdk<=0.15.0 # Apache-2.0


### PR DESCRIPTION
### Overview
- Python 3.5.10 support in eclsdk to use Python 3.5.10 in applications that use eclsdk.

### Detail
- requirements.txt
    - Changed openstacksdk version from 0.13.0 or lower to 0.15.0 or lower
    - Changed keystoneauth1 version from 3.4.0 or lower to 3.8.0 or lower
- ecl/session.py
    - The _send_request() parameter changed between 3.4.0 and 3.8.0 in keystoneauth1. The parameter was changed because _send_request() is overridden.