### PR TITLE
✨ Support Block storage Gen2 IF-16696

### DIFF
--- a/ecl/storage/v1/_proxy.py
+++ b/ecl/storage/v1/_proxy.py
@@ -222,6 +222,7 @@ class Proxy(proxy2.BaseProxy):
         :param throughput: Provisioned throughput for volume.
         :param initiator_iqns: List of initiator IQN who can access to this volume.
         :param availability_zone: Availability zone.
+        :param snapshot_reserve_size: Size of Snapshot Reserve
         :return: :class:`~ecl.storage.v1.volume.Volume`
         """
         body = {"virtual_storage_id": virtual_storage_id, "name": name, "size": size}
@@ -235,6 +236,8 @@ class Proxy(proxy2.BaseProxy):
             body["initiator_iqns"] = initiator_iqns
         if availability_zone:
             body["availability_zone"] = availability_zone
+        if snapshot_reserve_size:
+            body["snapshot_reserve_size"] = snapshot_reserve_size
         volume = _volume.Volume()
         return volume.create(self.session, **body)
 

--- a/ecl/storage/v1/_proxy.py
+++ b/ecl/storage/v1/_proxy.py
@@ -211,7 +211,7 @@ class Proxy(proxy2.BaseProxy):
 
     def create_volume(self, virtual_storage_id, name, size, description=None,
                       iops_per_gb=None, initiator_iqns=None, throughput=None,
-                      availability_zone=None):
+                      availability_zone=None, snapshot_reserve_size=None):
         """This API create additional Volume.
 
         :param virtual_storage_id: Virtual Storage ID.

--- a/ecl/storage/v1/volume.py
+++ b/ecl/storage/v1/volume.py
@@ -73,9 +73,6 @@ class Volume(resource2.Resource):
     #: Percentage of Used Snapshots
     percentage_snapshot_reserve_used = \
         resource2.Body('percentage_snapshot_reserve_used', type=int)
-    #: Percentage of Snapshots Reserve
-    percentage_snapshot_reserve = \
-        resource2.Body('percentage_snapshot_reserve', type=int)
     #: The size of Snapshots Reserve
     snapshot_reserve_size = \
         resource2.Body('snapshot_reserve_size', type=int)

--- a/ecl/storage/v1/volume.py
+++ b/ecl/storage/v1/volume.py
@@ -73,6 +73,15 @@ class Volume(resource2.Resource):
     #: Percentage of Used Snapshots
     percentage_snapshot_reserve_used = \
         resource2.Body('percentage_snapshot_reserve_used', type=int)
+    #: Percentage of Snapshots Reserve
+    percentage_snapshot_reserve = \
+        resource2.Body('percentage_snapshot_reserve', type=int)
+    #: The size of Snapshots Reserve
+    snapshot_reserve_size = \
+        resource2.Body('snapshot_reserve_size', type=int)
+    #: The size of Used Snapshots Reserve
+    snapshot_reserve_used = \
+        resource2.Body('snapshot_reserve_used', type=int)
     #: properties for smb storage
     smb_properties = resource2.Body('smb_properties', type=dict)
 

--- a/ecl/tests/functional/storage/v1/test_volume.py
+++ b/ecl/tests/functional/storage/v1/test_volume.py
@@ -12,6 +12,7 @@
 
 import six
 import time
+
 from ecl.tests.functional import base
 
 
@@ -23,31 +24,43 @@ class TestVolume(base.BaseFunctionalTest):
         # required
         self.assertIsInstance(volume.id, six.string_types)
         self.assertIsInstance(volume.name, six.string_types)
-        self.assertIsInstance(volume.description, six.string_types)
+        if volume.description is not None:
+            self.assertIsInstance(volume.description, six.string_types)
+        else:
+            self.assertIsNone(volume.description)
         self.assertIsInstance(volume.virtual_storage_id, six.string_types)
         self.assertIsInstance(volume.status, six.string_types)
-        self.assertIsInstance(volume.size, int)
-        self.assertIsInstance(volume.created_at, six.string_types)
-        self.assertIsInstance(volume.updated_at, six.string_types)
+        self.assertIsInstance(volume.size, six.integer_types)
+        if volume.created_at is not None:
+            self.assertIsInstance(volume.created_at, six.string_types)
+        else:
+            self.assertIsNone(volume.created_at)
+        if volume.updated_at is not None:
+            self.assertIsInstance(volume.updated_at, Null or six.string_types)
+        else:
+            self.assertIsNone(volume.updated_at)
         self.assertIsInstance(volume.error_message, six.string_types)
         self.assertIsInstance(volume.target_ips, list)
-        self.assertIsInstance(volume.availability_zone, six.string_types)
-        self.assertIsInstance(volume.snapshot_ids, six.string_types)
+        if volume.availability_zone is not None:
+            self.assertIsInstance(volume.availability_zone, six.string_types)
+        else:
+            self.assertIsNone(volume.availability_zone)
+        self.assertIsInstance(volume.snapshot_ids, list)
         self.assertIsInstance(volume.encrypt, bool)
 
         # Only available for "piops_iscsi_na" or "piops_iscsi_na2" volumes
-        self.assertIsInstance(volume.percentage_snapshot_reserve_used, int)
+        self.assertIsInstance(volume.percentage_snapshot_reserve_used, six.integer_types)
 
         # Only available for "piops_iscsi_na" volumes
-        # self.assertIsInstance(volume.iops_per_gb, int)
+        # self.assertIsInstance(volume.iops_per_gb, six.integer_types)
         # self.assertIsInstance(volume.initiator_iqns, list)
-        # self.assertIsInstance(volume.initiator_secret, null)
-        # self.assertIsInstance(volume.target_secret, null)
+        # self.assertIsNone(volume.initiator_secret)
+        # self.assertIsNone(volume.target_secret)
         # self.assertIsInstance(volume.metadata, dict)
 
         # Only available for "piops_iscsi_na2" volumes
-        self.assertIsInstance(volume.snapshot_reserve_size, int)
-        self.assertIsInstance(volume.snapshot_reserve_used, int)
+        self.assertIsInstance(volume.snapshot_reserve_size, six.integer_types)
+        self.assertIsInstance(volume.snapshot_reserve_used, six.integer_types)
 
         # Only available for "standard_nfs_na" or "standard_smb_na" volumes
         # self.assertIsInstance(volume.export_rules, list)
@@ -61,31 +74,43 @@ class TestVolume(base.BaseFunctionalTest):
         # required
         self.assertIsInstance(volume.id, six.string_types)
         self.assertIsInstance(volume.name, six.string_types)
-        self.assertIsInstance(volume.description, six.string_types)
+        if volume.description is not None:
+            self.assertIsInstance(volume.description, six.string_types)
+        else:
+            self.assertIsNone(volume.description)
         self.assertIsInstance(volume.virtual_storage_id, six.string_types)
         self.assertIsInstance(volume.status, six.string_types)
-        self.assertIsInstance(volume.size, int)
-        self.assertIsInstance(volume.created_at, six.string_types)
-        self.assertIsInstance(volume.updated_at, six.string_types)
+        self.assertIsInstance(volume.size, six.integer_types)
+        if volume.created_at is not None:
+            self.assertIsInstance(volume.created_at, six.string_types)
+        else:
+            self.assertIsNone(volume.created_at)
+        if volume.updated_at is not None:
+            self.assertIsInstance(volume.updated_at, Null or six.string_types)
+        else:
+            self.assertIsNone(volume.updated_at)
         self.assertIsInstance(volume.error_message, six.string_types)
         self.assertIsInstance(volume.target_ips, list)
-        self.assertIsInstance(volume.availability_zone, six.string_types)
-        self.assertIsInstance(volume.snapshot_ids, six.string_types)
+        if volume.availability_zone is not None:
+            self.assertIsInstance(volume.availability_zone, six.string_types)
+        else:
+            self.assertIsNone(volume.availability_zone)
+        self.assertIsInstance(volume.snapshot_ids, list)
         self.assertIsInstance(volume.encrypt, bool)
 
         # Only available for "piops_iscsi_na" or "piops_iscsi_na2" volumes
-        self.assertIsInstance(volume.percentage_snapshot_reserve_used, int)
+        self.assertIsInstance(volume.percentage_snapshot_reserve_used, six.integer_types)
 
         # Only available for "piops_iscsi_na" volumes
-        # self.assertIsInstance(volume.iops_per_gb, int)
+        # self.assertIsInstance(volume.iops_per_gb, six.integer_types)
         # self.assertIsInstance(volume.initiator_iqns, list)
-        # self.assertIsInstance(volume.initiator_secret, null)
-        # self.assertIsInstance(volume.target_secret, null)
+        # self.assertIsNone(volume.initiator_secret)
+        # self.assertIsNone(volume.target_secret)
         # self.assertIsInstance(volume.metadata, dict)
 
         # Only available for "piops_iscsi_na2" volumes
-        self.assertIsInstance(volume.snapshot_reserve_size, int)
-        self.assertIsInstance(volume.snapshot_reserve_used, int)
+        self.assertIsInstance(volume.snapshot_reserve_size, six.integer_types)
+        self.assertIsInstance(volume.snapshot_reserve_used, six.integer_types)
 
         # Only available for "standard_nfs_na" or "standard_smb_na" volumes
         # self.assertIsInstance(volume.export_rules, list)
@@ -103,31 +128,43 @@ class TestVolume(base.BaseFunctionalTest):
         # required
         self.assertIsInstance(volume.id, six.string_types)
         self.assertIsInstance(volume.name, six.string_types)
-        self.assertIsInstance(volume.description, six.string_types)
+        if volume.description is not None:
+            self.assertIsInstance(volume.description, six.string_types)
+        else:
+            self.assertIsNone(volume.description)
         self.assertIsInstance(volume.virtual_storage_id, six.string_types)
         self.assertIsInstance(volume.status, six.string_types)
-        self.assertIsInstance(volume.size, int)
-        self.assertIsInstance(volume.created_at, six.string_types)
-        self.assertIsInstance(volume.updated_at, six.string_types)
+        self.assertIsInstance(volume.size, six.integer_types)
+        if volume.created_at is not None:
+            self.assertIsInstance(volume.created_at, six.string_types)
+        else:
+            self.assertIsNone(volume.created_at)
+        if volume.updated_at is not None:
+            self.assertIsInstance(volume.updated_at, Null or six.string_types)
+        else:
+            self.assertIsNone(volume.updated_at)
         self.assertIsInstance(volume.error_message, six.string_types)
         self.assertIsInstance(volume.target_ips, list)
-        self.assertIsInstance(volume.availability_zone, six.string_types)
-        self.assertIsInstance(volume.snapshot_ids, six.string_types)
+        if volume.availability_zone is not None:
+            self.assertIsInstance(volume.availability_zone, six.string_types)
+        else:
+            self.assertIsNone(volume.availability_zone)
+        self.assertIsInstance(volume.snapshot_ids, list)
         self.assertIsInstance(volume.encrypt, bool)
 
         # Only available for "piops_iscsi_na" or "piops_iscsi_na2" volumes
-        self.assertIsInstance(volume.percentage_snapshot_reserve_used, int)
+        self.assertIsInstance(volume.percentage_snapshot_reserve_used, six.integer_types)
 
         # Only available for "piops_iscsi_na" volumes
-        # self.assertIsInstance(volume.iops_per_gb, int)
+        # self.assertIsInstance(volume.iops_per_gb, six.integer_types)
         # self.assertIsInstance(volume.initiator_iqns, list)
-        # self.assertIsInstance(volume.initiator_secret, null)
-        # self.assertIsInstance(volume.target_secret, null)
+        # self.assertIsNone(volume.initiator_secret)
+        # self.assertIsNone(volume.target_secret)
         # self.assertIsInstance(volume.metadata, dict)
 
         # Only available for "piops_iscsi_na2" volumes
-        self.assertIsInstance(volume.snapshot_reserve_size, int)
-        self.assertIsInstance(volume.snapshot_reserve_used, int)
+        self.assertIsInstance(volume.snapshot_reserve_size, six.integer_types)
+        self.assertIsInstance(volume.snapshot_reserve_used, six.integer_types)
 
         # Only available for "standard_nfs_na" or "standard_smb_na" volumes
         # self.assertIsInstance(volume.export_rules, list)
@@ -144,39 +181,51 @@ class TestVolume(base.BaseFunctionalTest):
         )
 
         # required
-        assert isInstance(volume.id, six.string_types)
-        assert isInstance(volume.name, six.string_types)
-        assert isInstance(volume.description, six.string_types)
-        assert isInstance(volume.virtual_storage_id, six.string_types)
-        assert isInstance(volume.status, six.string_types)
-        assert isInstance(volume.size, int)
-        assert isInstance(volume.created_at, six.string_types)
-        assert isInstance(volume.updated_at, six.string_types)
-        assert isInstance(volume.error_message, six.string_types)
-        assert isInstance(volume.target_ips, list)
-        assert isInstance(volume.availability_zone, six.string_types)
-        assert isInstance(volume.snapshot_ids, six.string_types)
-        assert isInstance(volume.encrypt, bool)
+        self.assertIsInstance(volume.id, six.string_types)
+        self.assertIsInstance(volume.name, six.string_types)
+        if volume.description is not None:
+            self.assertIsInstance(volume.description, six.string_types)
+        else:
+            self.assertIsNone(volume.description)
+        self.assertIsInstance(volume.virtual_storage_id, six.string_types)
+        self.assertIsInstance(volume.status, six.string_types)
+        self.assertIsInstance(volume.size, six.integer_types)
+        if volume.created_at is not None:
+            self.assertIsInstance(volume.created_at, six.string_types)
+        else:
+            self.assertIsNone(volume.created_at)
+        if volume.updated_at is not None:
+            self.assertIsInstance(volume.updated_at, Null or six.string_types)
+        else:
+            self.assertIsNone(volume.updated_at)
+        self.assertIsInstance(volume.error_message, six.string_types)
+        self.assertIsInstance(volume.target_ips, list)
+        if volume.availability_zone is not None:
+            self.assertIsInstance(volume.availability_zone, six.string_types)
+        else:
+            self.assertIsNone(volume.availability_zone)
+        self.assertIsInstance(volume.snapshot_ids, list)
+        self.assertIsInstance(volume.encrypt, bool)
 
         # Only available for "piops_iscsi_na" or "piops_iscsi_na2" volumes
-        assert isInstance(volume.percentage_snapshot_reserve_used, int)
+        self.assertIsInstance(volume.percentage_snapshot_reserve_used, six.integer_types)
 
         # Only available for "piops_iscsi_na" volumes
-        # assert isInstance(volume.iops_per_gb, int)
-        # assert isInstance(volume.initiator_iqns, list)
-        # assert isInstance(volume.initiator_secret, null)
-        # assert isInstance(volume.target_secret, null)
-        # assert isInstance(volume.metadata, dict)
+        # self.assertIsInstance(volume.iops_per_gb, six.integer_types)
+        # self.assertIsInstance(volume.initiator_iqns, list)
+        # self.assertIsNone(volume.initiator_secret)
+        # self.assertIsNone(volume.target_secret)
+        # self.assertIsInstance(volume.metadata, dict)
 
         # Only available for "piops_iscsi_na2" volumes
-        assert isInstance(volume.snapshot_reserve_size, int)
-        assert isInstance(volume.snapshot_reserve_used, int)
+        self.assertIsInstance(volume.snapshot_reserve_size, six.integer_types)
+        self.assertIsInstance(volume.snapshot_reserve_used, six.integer_types)
 
         # Only available for "standard_nfs_na" or "standard_smb_na" volumes
-        # assert isInstance(volume.export_rules, list)
+        # self.assertIsInstance(volume.export_rules, list)
 
         # Only available for "standard_smb_na" volumes
-        # assert isInstance(volume.smb_properties, dict)
+        # self.assertIsInstance(volume.smb_properties, dict)
 
         cls.vol_id = volume.id
 

--- a/ecl/tests/functional/storage/v1/test_volume.py
+++ b/ecl/tests/functional/storage/v1/test_volume.py
@@ -19,37 +19,79 @@ class TestVolume(base.BaseFunctionalTest):
     def test_01_volumes(self):
         volumes = list(self.conn.storage.volumes(details=True))
         volume = volumes[1]
+
+        # required
         self.assertIsInstance(volume.id, six.string_types)
-        self.assertIsInstance(volume.status, six.string_types)
         self.assertIsInstance(volume.name, six.string_types)
-        self.assertIsInstance(volume.size, int)
         self.assertIsInstance(volume.description, six.string_types)
-        self.assertIsInstance(volume.iops_per_gb, six.string_types)
-        self.assertIsInstance(volume.initiator_iqns, list)
-        self.assertIsInstance(volume.target_ips, list)
-        self.assertIsInstance(volume.metadata, dict)
         self.assertIsInstance(volume.virtual_storage_id, six.string_types)
-        self.assertIsInstance(volume.availability_zone, six.string_types)
+        self.assertIsInstance(volume.status, six.string_types)
+        self.assertIsInstance(volume.size, int)
         self.assertIsInstance(volume.created_at, six.string_types)
         self.assertIsInstance(volume.updated_at, six.string_types)
-        self.assertIsInstance(volume.id, six.string_types)
+        self.assertIsInstance(volume.error_message, six.string_types)
+        self.assertIsInstance(volume.target_ips, list)
+        self.assertIsInstance(volume.availability_zone, six.string_types)
+        self.assertIsInstance(volume.snapshot_ids, six.string_types)
+        self.assertIsInstance(volume.encrypt, bool)
+
+        # Only available for "piops_iscsi_na" or "piops_iscsi_na2" volumes
+        self.assertIsInstance(volume.percentage_snapshot_reserve_used, int)
+
+        # Only available for "piops_iscsi_na" volumes
+        # self.assertIsInstance(volume.iops_per_gb, int)
+        # self.assertIsInstance(volume.initiator_iqns, list)
+        # self.assertIsInstance(volume.initiator_secret, null)
+        # self.assertIsInstance(volume.target_secret, null)
+        # self.assertIsInstance(volume.metadata, dict)
+
+        # Only available for "piops_iscsi_na2" volumes
+        self.assertIsInstance(volume.snapshot_reserve_size, int)
+        self.assertIsInstance(volume.snapshot_reserve_used, int)
+
+        # Only available for "standard_nfs_na" or "standard_smb_na" volumes
+        # self.assertIsInstance(volume.export_rules, list)
+
+        # Only available for "standard_smb_na" volumes
+        # self.assertIsInstance(volume.smb_properties, dict)
 
     def test_02_show_volume(self):
         volume = self.conn.storage.get_volume("4096336b-7035-412a-8148-ad999f0e0bc8")
+
+        # required
         self.assertIsInstance(volume.id, six.string_types)
-        self.assertIsInstance(volume.status, six.string_types)
         self.assertIsInstance(volume.name, six.string_types)
-        self.assertIsInstance(volume.size, int)
         self.assertIsInstance(volume.description, six.string_types)
-        self.assertIsInstance(volume.iops_per_gb, six.string_types)
-        self.assertIsInstance(volume.initiator_iqns, list)
-        self.assertIsInstance(volume.target_ips, list)
-        self.assertIsInstance(volume.metadata, dict)
         self.assertIsInstance(volume.virtual_storage_id, six.string_types)
-        self.assertIsInstance(volume.availability_zone, six.string_types)
+        self.assertIsInstance(volume.status, six.string_types)
+        self.assertIsInstance(volume.size, int)
         self.assertIsInstance(volume.created_at, six.string_types)
         self.assertIsInstance(volume.updated_at, six.string_types)
-        self.assertIsInstance(volume.id, six.string_types)
+        self.assertIsInstance(volume.error_message, six.string_types)
+        self.assertIsInstance(volume.target_ips, list)
+        self.assertIsInstance(volume.availability_zone, six.string_types)
+        self.assertIsInstance(volume.snapshot_ids, six.string_types)
+        self.assertIsInstance(volume.encrypt, bool)
+
+        # Only available for "piops_iscsi_na" or "piops_iscsi_na2" volumes
+        self.assertIsInstance(volume.percentage_snapshot_reserve_used, int)
+
+        # Only available for "piops_iscsi_na" volumes
+        # self.assertIsInstance(volume.iops_per_gb, int)
+        # self.assertIsInstance(volume.initiator_iqns, list)
+        # self.assertIsInstance(volume.initiator_secret, null)
+        # self.assertIsInstance(volume.target_secret, null)
+        # self.assertIsInstance(volume.metadata, dict)
+
+        # Only available for "piops_iscsi_na2" volumes
+        self.assertIsInstance(volume.snapshot_reserve_size, int)
+        self.assertIsInstance(volume.snapshot_reserve_used, int)
+
+        # Only available for "standard_nfs_na" or "standard_smb_na" volumes
+        # self.assertIsInstance(volume.export_rules, list)
+
+        # Only available for "standard_smb_na" volumes
+        # self.assertIsInstance(volume.smb_properties, dict)
 
     def test_03_update_volume(self):
         volume = self.conn.storage.update_volume(
@@ -57,20 +99,41 @@ class TestVolume(base.BaseFunctionalTest):
             description="updated_test"
         )
         print(volume.description)
+
+        # required
         self.assertIsInstance(volume.id, six.string_types)
-        self.assertIsInstance(volume.status, six.string_types)
         self.assertIsInstance(volume.name, six.string_types)
-        self.assertIsInstance(volume.size, int)
         self.assertIsInstance(volume.description, six.string_types)
-        self.assertIsInstance(volume.iops_per_gb, six.string_types)
-        self.assertIsInstance(volume.initiator_iqns, list)
-        self.assertIsInstance(volume.target_ips, list)
-        self.assertIsInstance(volume.metadata, dict)
         self.assertIsInstance(volume.virtual_storage_id, six.string_types)
-        self.assertIsInstance(volume.availability_zone, six.string_types)
+        self.assertIsInstance(volume.status, six.string_types)
+        self.assertIsInstance(volume.size, int)
         self.assertIsInstance(volume.created_at, six.string_types)
         self.assertIsInstance(volume.updated_at, six.string_types)
-        self.assertIsInstance(volume.id, six.string_types)
+        self.assertIsInstance(volume.error_message, six.string_types)
+        self.assertIsInstance(volume.target_ips, list)
+        self.assertIsInstance(volume.availability_zone, six.string_types)
+        self.assertIsInstance(volume.snapshot_ids, six.string_types)
+        self.assertIsInstance(volume.encrypt, bool)
+
+        # Only available for "piops_iscsi_na" or "piops_iscsi_na2" volumes
+        self.assertIsInstance(volume.percentage_snapshot_reserve_used, int)
+
+        # Only available for "piops_iscsi_na" volumes
+        # self.assertIsInstance(volume.iops_per_gb, int)
+        # self.assertIsInstance(volume.initiator_iqns, list)
+        # self.assertIsInstance(volume.initiator_secret, null)
+        # self.assertIsInstance(volume.target_secret, null)
+        # self.assertIsInstance(volume.metadata, dict)
+
+        # Only available for "piops_iscsi_na2" volumes
+        self.assertIsInstance(volume.snapshot_reserve_size, int)
+        self.assertIsInstance(volume.snapshot_reserve_used, int)
+
+        # Only available for "standard_nfs_na" or "standard_smb_na" volumes
+        # self.assertIsInstance(volume.export_rules, list)
+
+        # Only available for "standard_smb_na" volumes
+        # self.assertIsInstance(volume.smb_properties, dict)
 
     @classmethod
     def test_04_create_volume(cls):
@@ -79,18 +142,42 @@ class TestVolume(base.BaseFunctionalTest):
             size=100,
             virtual_storage_id="19ff4cba-3b86-4da1-9663-25ea74f9b0a9",
         )
-        assert isinstance(volume.id, six.string_types)
-        assert isinstance(volume.status, six.string_types)
-        assert isinstance(volume.name, six.string_types)
-        assert isinstance(volume.size, int)
-        assert isinstance(volume.description, six.string_types)
-        assert isinstance(volume.iops_per_gb, six.string_types)
-        assert isinstance(volume.initiator_iqns, list)
-        assert isinstance(volume.target_ips, list)
-        assert isinstance(volume.metadata, dict)
-        assert isinstance(volume.virtual_storage_id, six.string_types)
-        assert isinstance(volume.availability_zone, six.string_types)
-        assert isinstance(volume.created_at, six.string_types)
+
+        # required
+        assert isInstance(volume.id, six.string_types)
+        assert isInstance(volume.name, six.string_types)
+        assert isInstance(volume.description, six.string_types)
+        assert isInstance(volume.virtual_storage_id, six.string_types)
+        assert isInstance(volume.status, six.string_types)
+        assert isInstance(volume.size, int)
+        assert isInstance(volume.created_at, six.string_types)
+        assert isInstance(volume.updated_at, six.string_types)
+        assert isInstance(volume.error_message, six.string_types)
+        assert isInstance(volume.target_ips, list)
+        assert isInstance(volume.availability_zone, six.string_types)
+        assert isInstance(volume.snapshot_ids, six.string_types)
+        assert isInstance(volume.encrypt, bool)
+
+        # Only available for "piops_iscsi_na" or "piops_iscsi_na2" volumes
+        assert isInstance(volume.percentage_snapshot_reserve_used, int)
+
+        # Only available for "piops_iscsi_na" volumes
+        # assert isInstance(volume.iops_per_gb, int)
+        # assert isInstance(volume.initiator_iqns, list)
+        # assert isInstance(volume.initiator_secret, null)
+        # assert isInstance(volume.target_secret, null)
+        # assert isInstance(volume.metadata, dict)
+
+        # Only available for "piops_iscsi_na2" volumes
+        assert isInstance(volume.snapshot_reserve_size, int)
+        assert isInstance(volume.snapshot_reserve_used, int)
+
+        # Only available for "standard_nfs_na" or "standard_smb_na" volumes
+        # assert isInstance(volume.export_rules, list)
+
+        # Only available for "standard_smb_na" volumes
+        # assert isInstance(volume.smb_properties, dict)
+
         cls.vol_id = volume.id
 
     def test_05_delete_volume(self):

--- a/ecl/tests/functional/storage/v1/test_volume.py
+++ b/ecl/tests/functional/storage/v1/test_volume.py
@@ -21,102 +21,50 @@ class TestVolume(base.BaseFunctionalTest):
         volumes = list(self.conn.storage.volumes(details=True))
         volume = volumes[1]
 
-        # required
         self.assertIsInstance(volume.id, six.string_types)
         self.assertIsInstance(volume.name, six.string_types)
-        if volume.description is not None:
-            self.assertIsInstance(volume.description, six.string_types)
-        else:
-            self.assertIsNone(volume.description)
+        self.assertIsInstance(volume.description, six.string_types)
         self.assertIsInstance(volume.virtual_storage_id, six.string_types)
         self.assertIsInstance(volume.status, six.string_types)
         self.assertIsInstance(volume.size, six.integer_types)
-        if volume.created_at is not None:
-            self.assertIsInstance(volume.created_at, six.string_types)
-        else:
-            self.assertIsNone(volume.created_at)
-        if volume.updated_at is not None:
-            self.assertIsInstance(volume.updated_at, six.string_types)
-        else:
-            self.assertIsNone(volume.updated_at)
+        self.assertIsNone(volume.created_at)
+        self.assertIsNone(volume.updated_at)
         self.assertIsInstance(volume.error_message, six.string_types)
         self.assertIsInstance(volume.target_ips, list)
-        if volume.availability_zone is not None:
-            self.assertIsInstance(volume.availability_zone, six.string_types)
-        else:
-            self.assertIsNone(volume.availability_zone)
+        self.assertIsInstance(volume.availability_zone, six.string_types)
         self.assertIsInstance(volume.snapshot_ids, list)
-        # self.assertIsInstance(volume.encrypt, bool)
-
-        # Only available for "piops_iscsi_na" or "piops_iscsi_na2" volumes
+        self.assertIsInstance(volume.iops_per_gb, six.integer_types)
+        self.assertIsInstance(volume.initiator_iqns, list)
+        self.assertIsNone(volume.initiator_secret)
+        self.assertIsNone(volume.target_secret)
+        self.assertIsInstance(volume.metadata, dict)
         self.assertIsInstance(volume.percentage_snapshot_reserve_used, six.integer_types)
-
-        # Only available for "piops_iscsi_na" volumes
-        # self.assertIsInstance(volume.iops_per_gb, six.integer_types)
-        # self.assertIsInstance(volume.initiator_iqns, list)
-        # self.assertIsNone(volume.initiator_secret)
-        # self.assertIsNone(volume.target_secret)
-        # self.assertIsInstance(volume.metadata, dict)
-
-        # Only available for "piops_iscsi_na2" volumes
         self.assertIsInstance(volume.snapshot_reserve_size, six.integer_types)
         self.assertIsInstance(volume.snapshot_reserve_used, six.integer_types)
-
-        # Only available for "standard_nfs_na" or "standard_smb_na" volumes
-        # self.assertIsInstance(volume.export_rules, list)
-
-        # Only available for "standard_smb_na" volumes
-        # self.assertIsInstance(volume.smb_properties, dict)
 
     def test_02_show_volume(self):
         volume = self.conn.storage.get_volume("4096336b-7035-412a-8148-ad999f0e0bc8")
 
-        # required
         self.assertIsInstance(volume.id, six.string_types)
         self.assertIsInstance(volume.name, six.string_types)
-        if volume.description is not None:
-            self.assertIsInstance(volume.description, six.string_types)
-        else:
-            self.assertIsNone(volume.description)
+        self.assertIsInstance(volume.description, six.string_types)
         self.assertIsInstance(volume.virtual_storage_id, six.string_types)
         self.assertIsInstance(volume.status, six.string_types)
         self.assertIsInstance(volume.size, six.integer_types)
-        if volume.created_at is not None:
-            self.assertIsInstance(volume.created_at, six.string_types)
-        else:
-            self.assertIsNone(volume.created_at)
-        if volume.updated_at is not None:
-            self.assertIsInstance(volume.updated_at, six.string_types)
-        else:
-            self.assertIsNone(volume.updated_at)
+        self.assertIsNone(volume.created_at)
+        self.assertIsNone(volume.updated_at)
         self.assertIsInstance(volume.error_message, six.string_types)
         self.assertIsInstance(volume.target_ips, list)
-        if volume.availability_zone is not None:
-            self.assertIsInstance(volume.availability_zone, six.string_types)
-        else:
-            self.assertIsNone(volume.availability_zone)
+        self.assertIsInstance(volume.availability_zone, six.string_types)
         self.assertIsInstance(volume.snapshot_ids, list)
-        # self.assertIsInstance(volume.encrypt, bool)
-
-        # Only available for "piops_iscsi_na" or "piops_iscsi_na2" volumes
+        self.assertIsInstance(volume.iops_per_gb, six.integer_types)
+        self.assertIsInstance(volume.initiator_iqns, list)
+        self.assertIsNone(volume.initiator_secret)
+        self.assertIsNone(volume.target_secret)
+        self.assertIsInstance(volume.metadata, dict)
         self.assertIsInstance(volume.percentage_snapshot_reserve_used, six.integer_types)
-
-        # Only available for "piops_iscsi_na" volumes
-        # self.assertIsInstance(volume.iops_per_gb, six.integer_types)
-        # self.assertIsInstance(volume.initiator_iqns, list)
-        # self.assertIsNone(volume.initiator_secret)
-        # self.assertIsNone(volume.target_secret)
-        # self.assertIsInstance(volume.metadata, dict)
-
-        # Only available for "piops_iscsi_na2" volumes
         self.assertIsInstance(volume.snapshot_reserve_size, six.integer_types)
         self.assertIsInstance(volume.snapshot_reserve_used, six.integer_types)
-
-        # Only available for "standard_nfs_na" or "standard_smb_na" volumes
-        # self.assertIsInstance(volume.export_rules, list)
-
-        # Only available for "standard_smb_na" volumes
-        # self.assertIsInstance(volume.smb_properties, dict)
 
     def test_03_update_volume(self):
         volume = self.conn.storage.update_volume(
@@ -125,52 +73,26 @@ class TestVolume(base.BaseFunctionalTest):
         )
         print(volume.description)
 
-        # required
         self.assertIsInstance(volume.id, six.string_types)
         self.assertIsInstance(volume.name, six.string_types)
-        if volume.description is not None:
-            self.assertIsInstance(volume.description, six.string_types)
-        else:
-            self.assertIsNone(volume.description)
+        self.assertIsInstance(volume.description, six.string_types)
         self.assertIsInstance(volume.virtual_storage_id, six.string_types)
         self.assertIsInstance(volume.status, six.string_types)
         self.assertIsInstance(volume.size, six.integer_types)
-        if volume.created_at is not None:
-            self.assertIsInstance(volume.created_at, six.string_types)
-        else:
-            self.assertIsNone(volume.created_at)
-        if volume.updated_at is not None:
-            self.assertIsInstance(volume.updated_at, six.string_types)
-        else:
-            self.assertIsNone(volume.updated_at)
+        self.assertIsNone(volume.created_at)
+        self.assertIsNone(volume.updated_at)
         self.assertIsInstance(volume.error_message, six.string_types)
         self.assertIsInstance(volume.target_ips, list)
-        if volume.availability_zone is not None:
-            self.assertIsInstance(volume.availability_zone, six.string_types)
-        else:
-            self.assertIsNone(volume.availability_zone)
+        self.assertIsInstance(volume.availability_zone, six.string_types)
         self.assertIsInstance(volume.snapshot_ids, list)
-        # self.assertIsInstance(volume.encrypt, bool)
-
-        # Only available for "piops_iscsi_na" or "piops_iscsi_na2" volumes
+        self.assertIsInstance(volume.iops_per_gb, six.integer_types)
+        self.assertIsInstance(volume.initiator_iqns, list)
+        self.assertIsNone(volume.initiator_secret)
+        self.assertIsNone(volume.target_secret)
+        self.assertIsInstance(volume.metadata, dict)
         self.assertIsInstance(volume.percentage_snapshot_reserve_used, six.integer_types)
-
-        # Only available for "piops_iscsi_na" volumes
-        # self.assertIsInstance(volume.iops_per_gb, six.integer_types)
-        # self.assertIsInstance(volume.initiator_iqns, list)
-        # self.assertIsNone(volume.initiator_secret)
-        # self.assertIsNone(volume.target_secret)
-        # self.assertIsInstance(volume.metadata, dict)
-
-        # Only available for "piops_iscsi_na2" volumes
         self.assertIsInstance(volume.snapshot_reserve_size, six.integer_types)
         self.assertIsInstance(volume.snapshot_reserve_used, six.integer_types)
-
-        # Only available for "standard_nfs_na" or "standard_smb_na" volumes
-        # self.assertIsInstance(volume.export_rules, list)
-
-        # Only available for "standard_smb_na" volumes
-        # self.assertIsInstance(volume.smb_properties, dict)
 
     @classmethod
     def test_04_create_volume(cls):
@@ -180,52 +102,26 @@ class TestVolume(base.BaseFunctionalTest):
             virtual_storage_id="19ff4cba-3b86-4da1-9663-25ea74f9b0a9",
         )
 
-        # required
         assert isinstance(volume.id, six.string_types)
         assert isinstance(volume.name, six.string_types)
-        if volume.description is not None:
-            assert isinstance(volume.description, six.string_types)
-        else:
-            assert volume.description is None
+        assert isinstance(volume.description, six.string_types)
         assert isinstance(volume.virtual_storage_id, six.string_types)
         assert isinstance(volume.status, six.string_types)
         assert isinstance(volume.size, six.integer_types)
-        if volume.created_at is not None:
-            assert isinstance(volume.created_at, six.string_types)
-        else:
-            assert volume.created_at is None
-        if volume.updated_at is not None:
-            assert isinstance(volume.updated_at, six.string_types)
-        else:
-            assert volume.updated_at is None
+        assert volume.created_at is None
+        assert volume.updated_at is None
         assert isinstance(volume.error_message, six.string_types)
         assert isinstance(volume.target_ips, list)
-        if volume.availability_zone is not None:
-            assert isinstance(volume.availability_zone, six.string_types)
-        else:
-            assert volume.availability_zone is None
+        assert isinstance(volume.availability_zone, six.string_types)
         assert isinstance(volume.snapshot_ids, list)
-        # assert isinstance(volume.encrypt, bool)
-
-        # Only available for "piops_iscsi_na" or "piops_iscsi_na2" volumes
+        assert isinstance(volume.iops_per_gb, six.integer_types)
+        assert isinstance(volume.initiator_iqns, list)
+        assert volume.initiator_secret is None
+        assert volume.target_secret is None
+        assert isinstance(volume.metadata, dict)
         assert isinstance(volume.percentage_snapshot_reserve_used, six.integer_types)
-
-        # Only available for "piops_iscsi_na" volumes
-        # assert isinstance(volume.iops_per_gb, six.integer_types)
-        # assert isinstance(volume.initiator_iqns, list)
-        # assert volume.initiator_secret is None
-        # assert volume.target_secret is None
-        # assert isinstance(volume.metadata, dict)
-
-        # Only available for "piops_iscsi_na2" volumes
         assert isinstance(volume.snapshot_reserve_size, six.integer_types)
         assert isinstance(volume.snapshot_reserve_used, six.integer_types)
-
-        # Only available for "standard_nfs_na" or "standard_smb_na" volumes
-        # assert isinstance(volume.export_rules, list)
-
-        # Only available for "standard_smb_na" volumes
-        # assert isinstance(volume.smb_properties, dict)
 
         cls.vol_id = volume.id
 

--- a/ecl/tests/functional/storage/v1/test_volume.py
+++ b/ecl/tests/functional/storage/v1/test_volume.py
@@ -36,7 +36,7 @@ class TestVolume(base.BaseFunctionalTest):
         else:
             self.assertIsNone(volume.created_at)
         if volume.updated_at is not None:
-            self.assertIsInstance(volume.updated_at, Null or six.string_types)
+            self.assertIsInstance(volume.updated_at, six.string_types)
         else:
             self.assertIsNone(volume.updated_at)
         self.assertIsInstance(volume.error_message, six.string_types)
@@ -86,7 +86,7 @@ class TestVolume(base.BaseFunctionalTest):
         else:
             self.assertIsNone(volume.created_at)
         if volume.updated_at is not None:
-            self.assertIsInstance(volume.updated_at, Null or six.string_types)
+            self.assertIsInstance(volume.updated_at, six.string_types)
         else:
             self.assertIsNone(volume.updated_at)
         self.assertIsInstance(volume.error_message, six.string_types)
@@ -140,7 +140,7 @@ class TestVolume(base.BaseFunctionalTest):
         else:
             self.assertIsNone(volume.created_at)
         if volume.updated_at is not None:
-            self.assertIsInstance(volume.updated_at, Null or six.string_types)
+            self.assertIsInstance(volume.updated_at, six.string_types)
         else:
             self.assertIsNone(volume.updated_at)
         self.assertIsInstance(volume.error_message, six.string_types)
@@ -195,7 +195,7 @@ class TestVolume(base.BaseFunctionalTest):
         else:
             assert volume.created_at is None
         if volume.updated_at is not None:
-            assert isinstance(volume.updated_at, Null or six.string_types)
+            assert isinstance(volume.updated_at, six.string_types)
         else:
             assert volume.updated_at is None
         assert isinstance(volume.error_message, six.string_types)

--- a/ecl/tests/functional/storage/v1/test_volume.py
+++ b/ecl/tests/functional/storage/v1/test_volume.py
@@ -46,7 +46,7 @@ class TestVolume(base.BaseFunctionalTest):
         else:
             self.assertIsNone(volume.availability_zone)
         self.assertIsInstance(volume.snapshot_ids, list)
-        self.assertIsInstance(volume.encrypt, bool)
+        # self.assertIsInstance(volume.encrypt, bool)
 
         # Only available for "piops_iscsi_na" or "piops_iscsi_na2" volumes
         self.assertIsInstance(volume.percentage_snapshot_reserve_used, six.integer_types)
@@ -96,7 +96,7 @@ class TestVolume(base.BaseFunctionalTest):
         else:
             self.assertIsNone(volume.availability_zone)
         self.assertIsInstance(volume.snapshot_ids, list)
-        self.assertIsInstance(volume.encrypt, bool)
+        # self.assertIsInstance(volume.encrypt, bool)
 
         # Only available for "piops_iscsi_na" or "piops_iscsi_na2" volumes
         self.assertIsInstance(volume.percentage_snapshot_reserve_used, six.integer_types)
@@ -150,7 +150,7 @@ class TestVolume(base.BaseFunctionalTest):
         else:
             self.assertIsNone(volume.availability_zone)
         self.assertIsInstance(volume.snapshot_ids, list)
-        self.assertIsInstance(volume.encrypt, bool)
+        # self.assertIsInstance(volume.encrypt, bool)
 
         # Only available for "piops_iscsi_na" or "piops_iscsi_na2" volumes
         self.assertIsInstance(volume.percentage_snapshot_reserve_used, six.integer_types)
@@ -181,51 +181,51 @@ class TestVolume(base.BaseFunctionalTest):
         )
 
         # required
-        self.assertIsInstance(volume.id, six.string_types)
-        self.assertIsInstance(volume.name, six.string_types)
+        assert isinstance(volume.id, six.string_types)
+        assert isinstance(volume.name, six.string_types)
         if volume.description is not None:
-            self.assertIsInstance(volume.description, six.string_types)
+            assert isinstance(volume.description, six.string_types)
         else:
-            self.assertIsNone(volume.description)
-        self.assertIsInstance(volume.virtual_storage_id, six.string_types)
-        self.assertIsInstance(volume.status, six.string_types)
-        self.assertIsInstance(volume.size, six.integer_types)
+            assert volume.description is None
+        assert isinstance(volume.virtual_storage_id, six.string_types)
+        assert isinstance(volume.status, six.string_types)
+        assert isinstance(volume.size, six.integer_types)
         if volume.created_at is not None:
-            self.assertIsInstance(volume.created_at, six.string_types)
+            assert isinstance(volume.created_at, six.string_types)
         else:
-            self.assertIsNone(volume.created_at)
+            assert volume.created_at is None
         if volume.updated_at is not None:
-            self.assertIsInstance(volume.updated_at, Null or six.string_types)
+            assert isinstance(volume.updated_at, Null or six.string_types)
         else:
-            self.assertIsNone(volume.updated_at)
-        self.assertIsInstance(volume.error_message, six.string_types)
-        self.assertIsInstance(volume.target_ips, list)
+            assert volume.updated_at is None
+        assert isinstance(volume.error_message, six.string_types)
+        assert isinstance(volume.target_ips, list)
         if volume.availability_zone is not None:
-            self.assertIsInstance(volume.availability_zone, six.string_types)
+            assert isinstance(volume.availability_zone, six.string_types)
         else:
-            self.assertIsNone(volume.availability_zone)
-        self.assertIsInstance(volume.snapshot_ids, list)
-        self.assertIsInstance(volume.encrypt, bool)
+            assert volume.availability_zone is None
+        assert isinstance(volume.snapshot_ids, list)
+        # assert isinstance(volume.encrypt, bool)
 
         # Only available for "piops_iscsi_na" or "piops_iscsi_na2" volumes
-        self.assertIsInstance(volume.percentage_snapshot_reserve_used, six.integer_types)
+        assert isinstance(volume.percentage_snapshot_reserve_used, six.integer_types)
 
         # Only available for "piops_iscsi_na" volumes
-        # self.assertIsInstance(volume.iops_per_gb, six.integer_types)
-        # self.assertIsInstance(volume.initiator_iqns, list)
-        # self.assertIsNone(volume.initiator_secret)
-        # self.assertIsNone(volume.target_secret)
-        # self.assertIsInstance(volume.metadata, dict)
+        # assert isinstance(volume.iops_per_gb, six.integer_types)
+        # assert isinstance(volume.initiator_iqns, list)
+        # assert volume.initiator_secret is None
+        # assert volume.target_secret is None
+        # assert isinstance(volume.metadata, dict)
 
         # Only available for "piops_iscsi_na2" volumes
-        self.assertIsInstance(volume.snapshot_reserve_size, six.integer_types)
-        self.assertIsInstance(volume.snapshot_reserve_used, six.integer_types)
+        assert isinstance(volume.snapshot_reserve_size, six.integer_types)
+        assert isinstance(volume.snapshot_reserve_used, six.integer_types)
 
         # Only available for "standard_nfs_na" or "standard_smb_na" volumes
-        # self.assertIsInstance(volume.export_rules, list)
+        # assert isinstance(volume.export_rules, list)
 
         # Only available for "standard_smb_na" volumes
-        # self.assertIsInstance(volume.smb_properties, dict)
+        # assert isinstance(volume.smb_properties, dict)
 
         cls.vol_id = volume.id
 

--- a/ecl/tests/unit/storage/v1/test_volume.py
+++ b/ecl/tests/unit/storage/v1/test_volume.py
@@ -35,6 +35,9 @@ BASIC_EXAMPLE = {
     'error_message': '',
     'throughput': 50,
     'export_rules': [],
+    'percentage_snapshot_reserve_used': 50,
+    'snapshot_reserve_size': 12,
+    'snapshot_reserve_used': 6,
     'smb_properties': {
         'workgroup': 'WORKGROUP',
         'users': [{
@@ -93,3 +96,6 @@ class TestVolume(testtools.TestCase):
         self.assertEqual(BASIC_EXAMPLE['throughput'], sot.throughput)
         self.assertEqual(BASIC_EXAMPLE['export_rules'], sot.export_rules)
         self.assertEqual(BASIC_EXAMPLE['smb_properties'], sot.smb_properties)
+        self.assertEqual(BASIC_EXAMPLE['percentage_snapshot_reserve_used'], sot.percentage_snapshot_reserve_used)
+        self.assertEqual(BASIC_EXAMPLE['snapshot_reserve_size'], sot.snapshot_reserve_size)
+        self.assertEqual(BASIC_EXAMPLE['snapshot_reserve_used'], sot.snapshot_reserve_used)


### PR DESCRIPTION
### Overview
* Add snapshot_reserve_size, snapshot_reserve_used to the volume API.

### Detail
 - ecl/storage/v1/_proxy.py
   - create_volume
     - Add arguments snapshot_reserve_size
 - ecl/storage/v1/volume.py
   - Volume
     - Add parameter snapshot_reserve_size
     - Add parameter snapshot_reserve_used
 - ecl/tests/functional/storage/v1/test_volume.py
   - test_make_basic
     - Add test code percentage_snapshot_reserve_used
     - Add test code snapshot_reserve_size
     - Add test code snapshot_reserve_used
 - ecl/tests/unit/storage/v1/test_volume.py
   - TestVolume
     - Overhaul test code to match Mock data
     - Fixed the type error that should be checked for the parameter "iops_per_gb"