### PR TITLE
✨Support Baremetal New RCA IF-16036

### DIFF
--- a/ecl/baremetal/v2/_proxy.py
+++ b/ecl/baremetal/v2/_proxy.py
@@ -485,7 +485,7 @@ class Proxy(proxy2.BaseProxy):
         :param string server_id: ID for the server.
         :return: :class:`~ecl.baremetal.v2.server.ServerAction`
         """
-        server = _server.ServerActionRemoteConsole()
+        server = _server.ServerAction()
         return server.get_remote_console_access(self.session, server_id)
 
     def disconnect_remote_console_access(self, server_id):
@@ -500,7 +500,7 @@ class Proxy(proxy2.BaseProxy):
         :param string server_id: ID for the server.
         :return: ``None``
         """
-        server = _server.ServerActionRemoteConsole()
+        server = _server.ServerAction()
         return server.disconnect_remote_console_access(self.session, server_id)
 
     def metadata(self, server_id):

--- a/ecl/baremetal/v2/_proxy.py
+++ b/ecl/baremetal/v2/_proxy.py
@@ -485,7 +485,7 @@ class Proxy(proxy2.BaseProxy):
         :param string server_id: ID for the server.
         :return: :class:`~ecl.baremetal.v2.server.ServerAction`
         """
-        server = _server.ServerAction()
+        server = _server.ServerActionRemoteConsole()
         return server.get_remote_console_access(self.session, server_id)
 
     def disconnect_remote_console_access(self, server_id):
@@ -500,7 +500,7 @@ class Proxy(proxy2.BaseProxy):
         :param string server_id: ID for the server.
         :return: ``None``
         """
-        server = _server.ServerAction()
+        server = _server.ServerActionRemoteConsole()
         return server.disconnect_remote_console_access(self.session, server_id)
 
     def metadata(self, server_id):

--- a/ecl/baremetal/v2/_proxy.py
+++ b/ecl/baremetal/v2/_proxy.py
@@ -467,6 +467,42 @@ class Proxy(proxy2.BaseProxy):
         server = _server.ServerAction()
         return server.reset_bmc(self.session, server_id, type)
 
+    def get_remote_console_access(self, server_id):
+        """This API provides the necessary information to access the Bare Metal Server's
+        Baseboard Management Controller (BMC).
+        Specifically, it provides the destination URL and the access_code
+        required for access.
+        By appending /remote-console-token-exchange to the issued
+        URL, and sending a POST request with the access_code
+        specified in the request body in JSON format ({ "access_code": "" }), the access_token
+        will be returned in the Set-Cookie field of the response header.
+        You can then access the Bare Metal Server's BMC by accessing the issuedURL
+        with this access_token specified in the Cookie.
+        Please note that the validity period for the access_code is 1 minute, and the validity
+        period for the access_token is 1 hour. Once the access_token is retrieved
+        from an access_code, that access_code becomes invalid.
+
+        :param string server_id: ID for the server.
+        :return: :class:`~ecl.baremetal.v2.server.ServerAction`
+        """
+        server = _server.ServerAction()
+        return server.get_remote_console_access(self.session, server_id)
+
+    def disconnect_remote_console_access(self, server_id):
+        """This API immediately revokes the access_token that was
+        issued by the aforementioned Get Remote Console Access
+        API, effectively expiring it prematurely.
+        Once the access_token is revoked, access to the BMC
+        using that access_token will no longer be possible, and
+        it will also become impossible to retrieve a access_token
+        using the access_code.
+
+        :param string server_id: ID for the server.
+        :return: ``None``
+        """
+        server = _server.ServerAction()
+        return server.disconnect_remote_console_access(self.session, server_id)
+
     def metadata(self, server_id):
         """This API lists metadata for a specified server.
 

--- a/ecl/baremetal/v2/server.py
+++ b/ecl/baremetal/v2/server.py
@@ -289,7 +289,6 @@ class ServerAction(resource2.Resource):
         return self
 
     def disconnect_remote_console_access(self, session, server_id):
-        self.resource_key = "remote_console"
         uri = self.base_path % server_id
         body = {
             "disconnect-remote-console": None

--- a/ecl/baremetal/v2/server.py
+++ b/ecl/baremetal/v2/server.py
@@ -281,7 +281,8 @@ class ServerAction(resource2.Resource):
         resp = session.post(
             uri,
             endpoint_filter=self.service,
-            json=body
+            json=body,
+            headers={"Accept": "application/json"}
         )
         self._translate_response(resp, has_body=True)
         return self
@@ -294,7 +295,8 @@ class ServerAction(resource2.Resource):
         resp = session.post(
             uri,
             endpoint_filter=self.service,
-            json=body
+            json=body,
+            headers={"Accept": "application/json"}
         )
         self._translate_response(resp, has_body=True)
         return self

--- a/ecl/baremetal/v2/server.py
+++ b/ecl/baremetal/v2/server.py
@@ -272,34 +272,34 @@ class ServerAction(resource2.Resource):
         )
         self._translate_response(resp, has_body=False)
         return self
-
-    def get_remote_console_access(self, session, server_id):
-        uri = self.base_path % server_id
-        body = {
-            "get-remote-console-url": None
-        }
-        resp = session.post(
-            uri,
-            endpoint_filter=self.service,
-            json=body,
-            headers={"Accept": "application/json"}
-        )
-        self._translate_response(resp, has_body=True)
-        return self
-
-    def disconnect_remote_console_access(self, session, server_id):
-        uri = self.base_path % server_id
-        body = {
-            "disconnect-remote-console": None
-        }
-        resp = session.post(
-            uri,
-            endpoint_filter=self.service,
-            json=body,
-            headers={"Accept": "application/json"}
-        )
-        self._translate_response(resp, has_body=True)
-        return self
+    #
+    # def get_remote_console_access(self, session, server_id):
+    #     uri = self.base_path % server_id
+    #     body = {
+    #         "get-remote-console-url": None
+    #     }
+    #     resp = session.post(
+    #         uri,
+    #         endpoint_filter=self.service,
+    #         json=body,
+    #         headers={"Accept": "application/json"}
+    #     )
+    #     self._translate_response(resp, has_body=True)
+    #     return self
+    #
+    # def disconnect_remote_console_access(self, session, server_id):
+    #     uri = self.base_path % server_id
+    #     body = {
+    #         "disconnect-remote-console": None
+    #     }
+    #     resp = session.post(
+    #         uri,
+    #         endpoint_filter=self.service,
+    #         json=body,
+    #         headers={"Accept": "application/json"}
+    #     )
+    #     self._translate_response(resp, has_body=True)
+    #     return self
 
     @classmethod
     def find(cls, session, name_or_id, ignore_missing=False, **params):

--- a/ecl/baremetal/v2/server.py
+++ b/ecl/baremetal/v2/server.py
@@ -272,7 +272,7 @@ class ServerAction(resource2.Resource):
         )
         self._translate_response(resp, has_body=False)
         return self
-    #
+
     # def get_remote_console_access(self, session, server_id):
     #     uri = self.base_path % server_id
     #     body = {
@@ -340,7 +340,7 @@ class ServerAction(resource2.Resource):
             "No %s found for %s" % (cls.__name__, name_or_id))
 
 class ServerActionRemoteConsole(resource2.Resource):
-    resource_key = "console"
+    resource_key = "remote_console"
     resources_key = None
     base_path = '/servers/%s/action'
     service = baremetal_service.BaremetalService()

--- a/ecl/baremetal/v2/server.py
+++ b/ecl/baremetal/v2/server.py
@@ -273,6 +273,35 @@ class ServerAction(resource2.Resource):
         self._translate_response(resp, has_body=False)
         return self
 
+    def get_remote_console_access(self, session, server_id):
+        self.resource_key = "remote_console"
+        uri = self.base_path % server_id
+        body = {
+            "get-remote-console-url": None
+        }
+        resp = session.post(
+            uri,
+            endpoint_filter=self.service,
+            json=body,
+            headers={"Accept": "application/json"}
+        )
+        self._translate_response(resp, has_body=True)
+        return self
+
+    def disconnect_remote_console_access(self, session, server_id):
+        self.resource_key = "remote_console"
+        uri = self.base_path % server_id
+        body = {
+            "disconnect-remote-console": None
+        }
+        resp = session.post(
+            uri,
+            endpoint_filter=self.service,
+            json=body
+        )
+        self._translate_response(resp, has_body=False)
+        return self
+
     @classmethod
     def find(cls, session, name_or_id, ignore_missing=False, **params):
         """Find a resource by its name or id.
@@ -310,44 +339,3 @@ class ServerAction(resource2.Resource):
             return None
         raise exceptions.ResourceNotFound(
             "No %s found for %s" % (cls.__name__, name_or_id))
-
-class ServerActionRemoteConsole(resource2.Resource):
-    resource_key = "remote_console"
-    resources_key = None
-    base_path = '/servers/%s/action'
-    service = baremetal_service.BaremetalService()
-
-    # Properties
-    #: URL to access the remote console.
-    url = resource2.Body('url')
-    #: Security token to get access_token.
-    access_code = resource2.Body('access_code')
-    #: Date and time when the access_code expires.
-    expired_at = resource2.Body('expired_at')
-
-    def get_remote_console_access(self, session, server_id):
-        uri = self.base_path % server_id
-        body = {
-            "get-remote-console-url": None
-        }
-        resp = session.post(
-            uri,
-            endpoint_filter=self.service,
-            json=body,
-            headers={"Accept": "application/json"}
-        )
-        self._translate_response(resp, has_body=True)
-        return self
-
-    def disconnect_remote_console_access(self, session, server_id):
-        uri = self.base_path % server_id
-        body = {
-            "disconnect-remote-console": None
-        }
-        resp = session.post(
-            uri,
-            endpoint_filter=self.service,
-            json=body
-        )
-        self._translate_response(resp, has_body=False)
-        return self

--- a/ecl/baremetal/v2/server.py
+++ b/ecl/baremetal/v2/server.py
@@ -349,5 +349,5 @@ class ServerActionRemoteConsole(resource2.Resource):
             endpoint_filter=self.service,
             json=body
         )
-        self._translate_response(resp, has_body=True)
+        self._translate_response(resp, has_body=False)
         return self

--- a/ecl/baremetal/v2/server.py
+++ b/ecl/baremetal/v2/server.py
@@ -153,6 +153,10 @@ class ServerAction(resource2.Resource):
     user_id = resource2.Body('user_id')
     #: Password for sign in to the remote console.
     password = resource2.Body('password')
+    #: Security token to get access_token.
+    access_code = resource2.Body('access_code')
+    #: Date and time when the access_code expires.
+    expired_at = resource2.Body('expired_at')
 
     def start(self, session, server_id):
         uri = self.base_path % server_id
@@ -267,6 +271,32 @@ class ServerAction(resource2.Resource):
             json=body
         )
         self._translate_response(resp, has_body=False)
+        return self
+
+    def get_remote_console_access(self, session, server_id):
+        uri = self.base_path % server_id
+        body = {
+            "get-remote-console-url": None
+        }
+        resp = session.post(
+            uri,
+            endpoint_filter=self.service,
+            json=body
+        )
+        self._translate_response(resp, has_body=True)
+        return self
+
+    def disconnect_remote_console_access(self, session, server_id):
+        uri = self.base_path % server_id
+        body = {
+            "disconnect-remote-console": None
+        }
+        resp = session.post(
+            uri,
+            endpoint_filter=self.service,
+            json=body
+        )
+        self._translate_response(resp, has_body=True)
         return self
 
     @classmethod

--- a/ecl/baremetal/v2/server.py
+++ b/ecl/baremetal/v2/server.py
@@ -347,8 +347,7 @@ class ServerActionRemoteConsole(resource2.Resource):
         resp = session.post(
             uri,
             endpoint_filter=self.service,
-            json=body,
-            headers={"Accept": "application/json"}
+            json=body
         )
         self._translate_response(resp, has_body=True)
         return self

--- a/ecl/baremetal/v2/server.py
+++ b/ecl/baremetal/v2/server.py
@@ -273,34 +273,6 @@ class ServerAction(resource2.Resource):
         self._translate_response(resp, has_body=False)
         return self
 
-    # def get_remote_console_access(self, session, server_id):
-    #     uri = self.base_path % server_id
-    #     body = {
-    #         "get-remote-console-url": None
-    #     }
-    #     resp = session.post(
-    #         uri,
-    #         endpoint_filter=self.service,
-    #         json=body,
-    #         headers={"Accept": "application/json"}
-    #     )
-    #     self._translate_response(resp, has_body=True)
-    #     return self
-    #
-    # def disconnect_remote_console_access(self, session, server_id):
-    #     uri = self.base_path % server_id
-    #     body = {
-    #         "disconnect-remote-console": None
-    #     }
-    #     resp = session.post(
-    #         uri,
-    #         endpoint_filter=self.service,
-    #         json=body,
-    #         headers={"Accept": "application/json"}
-    #     )
-    #     self._translate_response(resp, has_body=True)
-    #     return self
-
     @classmethod
     def find(cls, session, name_or_id, ignore_missing=False, **params):
         """Find a resource by its name or id.
@@ -380,4 +352,3 @@ class ServerActionRemoteConsole(resource2.Resource):
         )
         self._translate_response(resp, has_body=True)
         return self
-

--- a/ecl/baremetal/v2/server.py
+++ b/ecl/baremetal/v2/server.py
@@ -338,3 +338,46 @@ class ServerAction(resource2.Resource):
             return None
         raise exceptions.ResourceNotFound(
             "No %s found for %s" % (cls.__name__, name_or_id))
+
+class ServerActionRemoteConsole(resource2.Resource):
+    resource_key = "console"
+    resources_key = None
+    base_path = '/servers/%s/action'
+    service = baremetal_service.BaremetalService()
+
+    # Properties
+    #: URL to access the remote console.
+    url = resource2.Body('url')
+    #: Security token to get access_token.
+    access_code = resource2.Body('access_code')
+    #: Date and time when the access_code expires.
+    expired_at = resource2.Body('expired_at')
+
+    def get_remote_console_access(self, session, server_id):
+        uri = self.base_path % server_id
+        body = {
+            "get-remote-console-url": None
+        }
+        resp = session.post(
+            uri,
+            endpoint_filter=self.service,
+            json=body,
+            headers={"Accept": "application/json"}
+        )
+        self._translate_response(resp, has_body=True)
+        return self
+
+    def disconnect_remote_console_access(self, session, server_id):
+        uri = self.base_path % server_id
+        body = {
+            "disconnect-remote-console": None
+        }
+        resp = session.post(
+            uri,
+            endpoint_filter=self.service,
+            json=body,
+            headers={"Accept": "application/json"}
+        )
+        self._translate_response(resp, has_body=True)
+        return self
+

--- a/ecl/tests/functional/baremetal/test_server_action.py
+++ b/ecl/tests/functional/baremetal/test_server_action.py
@@ -19,28 +19,25 @@ class TestServerAction(base.BaseFunctionalTest):
 
     def test_01_start_server(self):
         server = self.conn.baremetal.start_server(
-            "752aac2e-4b82-4d47-a7c7-fcbd0cbc86e2",
-            "DISK"
+            "91f4e431-ab9d-422e-8f4f-9dcad809d18e"
         )
 
     def test_02_stop_server(self):
         server = self.conn.baremetal.stop_server(
-            "752aac2e-4b82-4d47-a7c7-fcbd0cbc86e2",
+            "91f4e431-ab9d-422e-8f4f-9dcad809d18e",
             None
         )
-        assert False
+        assert True
 
     def test_03_reboot_server(self):
         server = self.conn.baremetal.reboot_server(
-            "752aac2e-4b82-4d47-a7c7-fcbd0cbc86e2",
-            "SOFT",
-            "disk"
+            "91f4e431-ab9d-422e-8f4f-9dcad809d18e",
+            "SOFT"
         )
 
     def test_04_get_management_console(self):
         server = self.conn.baremetal.get_management_console(
-            "752aac2e-4b82-4d47-a7c7-fcbd0cbc86e2",
-            None
+            "91f4e431-ab9d-422e-8f4f-9dcad809d18e"
         )
         self.assertIsInstance(server.type, six.string_types)
         self.assertIsInstance(server.url, six.string_types)
@@ -49,8 +46,7 @@ class TestServerAction(base.BaseFunctionalTest):
 
     def test_05_get_remote_console_access(self):
         server = self.conn.baremetal.get_remote_console_access(
-            "752aac2e-4b82-4d47-a7c7-fcbd0cbc86e2",
-            None
+            "91f4e431-ab9d-422e-8f4f-9dcad809d18e",
         )
         self.assertIsInstance(server.url, six.string_types)
         self.assertIsInstance(server.access_code, six.string_types)
@@ -59,5 +55,4 @@ class TestServerAction(base.BaseFunctionalTest):
     def test_06_disconnect_remote_console_access(self):
         server = self.conn.baremetal.disconnect_remote_console_access(
             "752aac2e-4b82-4d47-a7c7-fcbd0cbc86e2",
-            None
         )

--- a/ecl/tests/functional/baremetal/test_server_action.py
+++ b/ecl/tests/functional/baremetal/test_server_action.py
@@ -46,3 +46,18 @@ class TestServerAction(base.BaseFunctionalTest):
         self.assertIsInstance(server.url, six.string_types)
         self.assertIsInstance(server.user_id, six.string_types)
         self.assertIsInstance(server.password, six.string_types)
+
+    def test_05_get_remote_console_access(self):
+        server = self.conn.baremetal.get_remote_console_access(
+            "752aac2e-4b82-4d47-a7c7-fcbd0cbc86e2",
+            None
+        )
+        self.assertIsInstance(server.url, six.string_types)
+        self.assertIsInstance(server.access_code, six.string_types)
+        self.assertIsInstance(server.expired_at, six.string_types)
+
+    def test_06_disconnect_remote_console_access(self):
+        server = self.conn.baremetal.disconnect_remote_console_access(
+            "752aac2e-4b82-4d47-a7c7-fcbd0cbc86e2",
+            None
+        )

--- a/ecl/tests/functional/baremetal/test_server_action.py
+++ b/ecl/tests/functional/baremetal/test_server_action.py
@@ -54,5 +54,5 @@ class TestServerAction(base.BaseFunctionalTest):
 
     def test_06_disconnect_remote_console_access(self):
         server = self.conn.baremetal.disconnect_remote_console_access(
-            "752aac2e-4b82-4d47-a7c7-fcbd0cbc86e2",
+            "91f4e431-ab9d-422e-8f4f-9dcad809d18e",
         )


### PR DESCRIPTION
### Overview
- Add get_remote_console_access and disconnect_remote_console_access to the server API.

### Detail
- ecl/baremetal/v2/_proxy.py
  - Proxy
    - Add get_remote_console_access
    - Add disconnect_remote_console_access

- ecl/baremetal/v2/server.py
  - ServerAction
    - Add get_remote_console_access
    - Add disconnect_remote_console_access
    - Add parameter access_code
    - Add parameter expired_at

- ecl/tests/functional/baremetal/test_server_action.py
  - TestServerAction
    - Add test_05_get_remote_console_access
    - Add test_06_disconnect_remote_console_access