### PR TITLE
✨Support Baremetal New RCA IF-16036

### DIFF
--- a/ecl/baremetal/v2/_proxy.py
+++ b/ecl/baremetal/v2/_proxy.py
@@ -485,7 +485,7 @@ class Proxy(proxy2.BaseProxy):
         :param string server_id: ID for the server.
         :return: :class:`~ecl.baremetal.v2.server.ServerAction`
         """
-        server = _server.ServerAction()
+        server = _server.ServerActionRemoteConsole()
         return server.get_remote_console_access(self.session, server_id)
 
     def disconnect_remote_console_access(self, server_id):
@@ -500,7 +500,7 @@ class Proxy(proxy2.BaseProxy):
         :param string server_id: ID for the server.
         :return: ``None``
         """
-        server = _server.ServerAction()
+        server = _server.ServerActionRemoteConsole()
         return server.disconnect_remote_console_access(self.session, server_id)
 
     def update_bmc_password(self, server_id, password):

--- a/ecl/baremetal/v2/_proxy.py
+++ b/ecl/baremetal/v2/_proxy.py
@@ -485,7 +485,7 @@ class Proxy(proxy2.BaseProxy):
         :param string server_id: ID for the server.
         :return: :class:`~ecl.baremetal.v2.server.ServerAction`
         """
-        server = _server.ServerActionRemoteConsole()
+        server = _server.ServerAction()
         return server.get_remote_console_access(self.session, server_id)
 
     def disconnect_remote_console_access(self, server_id):
@@ -500,7 +500,7 @@ class Proxy(proxy2.BaseProxy):
         :param string server_id: ID for the server.
         :return: ``None``
         """
-        server = _server.ServerActionRemoteConsole()
+        server = _server.ServerAction()
         return server.disconnect_remote_console_access(self.session, server_id)
 
     def update_bmc_password(self, server_id, password):

--- a/ecl/baremetal/v2/_proxy.py
+++ b/ecl/baremetal/v2/_proxy.py
@@ -467,6 +467,42 @@ class Proxy(proxy2.BaseProxy):
         server = _server.ServerAction()
         return server.reset_bmc(self.session, server_id, type)
 
+    def get_remote_console_access(self, server_id):
+        """This API provides the necessary information to access the Bare Metal Server's
+        Baseboard Management Controller (BMC).
+        Specifically, it provides the destination URL and the access_code
+        required for access.
+        By appending /remote-console-token-exchange to the issued
+        URL, and sending a POST request with the access_code
+        specified in the request body in JSON format ({ "access_code": "" }), the access_token
+        will be returned in the Set-Cookie field of the response header.
+        You can then access the Bare Metal Server's BMC by accessing the issuedURL
+        with this access_token specified in the Cookie.
+        Please note that the validity period for the access_code is 1 minute, and the validity
+        period for the access_token is 1 hour. Once the access_token is retrieved
+        from an access_code, that access_code becomes invalid.
+
+        :param string server_id: ID for the server.
+        :return: :class:`~ecl.baremetal.v2.server.ServerAction`
+        """
+        server = _server.ServerAction()
+        return server.get_remote_console_access(self.session, server_id)
+
+    def disconnect_remote_console_access(self, server_id):
+        """This API immediately revokes the access_token that was
+        issued by the aforementioned Get Remote Console Access
+        API, effectively expiring it prematurely.
+        Once the access_token is revoked, access to the BMC
+        using that access_token will no longer be possible, and
+        it will also become impossible to retrieve a access_token
+        using the access_code.
+
+        :param string server_id: ID for the server.
+        :return: ``None``
+        """
+        server = _server.ServerAction()
+        return server.disconnect_remote_console_access(self.session, server_id)
+
     def update_bmc_password(self, server_id, password):
         """Update the password for the Baseboard Management Controller
         of the Baremetal Server associated with server_id.

--- a/ecl/baremetal/v2/server.py
+++ b/ecl/baremetal/v2/server.py
@@ -382,8 +382,7 @@ class ServerActionRemoteConsole(resource2.Resource):
         resp = session.post(
             uri,
             endpoint_filter=self.service,
-            json=body,
-            headers={"Accept": "application/json"}
+            json=body
         )
         self._translate_response(resp, has_body=True)
         return self

--- a/ecl/baremetal/v2/server.py
+++ b/ecl/baremetal/v2/server.py
@@ -384,6 +384,6 @@ class ServerActionRemoteConsole(resource2.Resource):
             endpoint_filter=self.service,
             json=body
         )
-        self._translate_response(resp, has_body=True)
+        self._translate_response(resp, has_body=False)
         return self
 

--- a/ecl/baremetal/v2/server.py
+++ b/ecl/baremetal/v2/server.py
@@ -292,6 +292,14 @@ class ServerAction(resource2.Resource):
         uri = self.base_path % server_id
         body = {
             "disconnect-remote-console": None
+        }
+        resp = session.post(
+            uri,
+            endpoint_filter=self.service,
+            json=body
+        )
+        self._translate_response(resp, has_body=False)
+        return self
 
     def update_bmc_password(self, session, server_id, password):
         uri = self.base_path % server_id

--- a/ecl/baremetal/v2/server.py
+++ b/ecl/baremetal/v2/server.py
@@ -292,15 +292,7 @@ class ServerAction(resource2.Resource):
         uri = self.base_path % server_id
         body = {
             "disconnect-remote-console": None
-        }
-        resp = session.post(
-            uri,
-            endpoint_filter=self.service,
-            json=body
-        )
-        self._translate_response(resp, has_body=False)
-        return self
-
+          
     def update_bmc_password(self, session, server_id, password):
         uri = self.base_path % server_id
         body = {

--- a/ecl/baremetal/v2/server.py
+++ b/ecl/baremetal/v2/server.py
@@ -345,3 +345,46 @@ class ServerAction(resource2.Resource):
             return None
         raise exceptions.ResourceNotFound(
             "No %s found for %s" % (cls.__name__, name_or_id))
+
+class ServerActionRemoteConsole(resource2.Resource):
+    resource_key = "console"
+    resources_key = None
+    base_path = '/servers/%s/action'
+    service = baremetal_service.BaremetalService()
+
+    # Properties
+    #: URL to access the remote console.
+    url = resource2.Body('url')
+    #: Security token to get access_token.
+    access_code = resource2.Body('access_code')
+    #: Date and time when the access_code expires.
+    expired_at = resource2.Body('expired_at')
+
+    def get_remote_console_access(self, session, server_id):
+        uri = self.base_path % server_id
+        body = {
+            "get-remote-console-url": None
+        }
+        resp = session.post(
+            uri,
+            endpoint_filter=self.service,
+            json=body,
+            headers={"Accept": "application/json"}
+        )
+        self._translate_response(resp, has_body=True)
+        return self
+
+    def disconnect_remote_console_access(self, session, server_id):
+        uri = self.base_path % server_id
+        body = {
+            "disconnect-remote-console": None
+        }
+        resp = session.post(
+            uri,
+            endpoint_filter=self.service,
+            json=body,
+            headers={"Accept": "application/json"}
+        )
+        self._translate_response(resp, has_body=True)
+        return self
+

--- a/ecl/baremetal/v2/server.py
+++ b/ecl/baremetal/v2/server.py
@@ -153,6 +153,10 @@ class ServerAction(resource2.Resource):
     user_id = resource2.Body('user_id')
     #: Password for sign in to the remote console.
     password = resource2.Body('password')
+    #: Security token to get access_token.
+    access_code = resource2.Body('access_code')
+    #: Date and time when the access_code expires.
+    expired_at = resource2.Body('expired_at')
 
     def start(self, session, server_id):
         uri = self.base_path % server_id
@@ -260,6 +264,34 @@ class ServerAction(resource2.Resource):
             "bmc-reset": {
                 "type": type
             }
+        }
+        resp = session.post(
+            uri,
+            endpoint_filter=self.service,
+            json=body
+        )
+        self._translate_response(resp, has_body=False)
+        return self
+
+    def get_remote_console_access(self, session, server_id):
+        self.resource_key = "remote_console"
+        uri = self.base_path % server_id
+        body = {
+            "get-remote-console-url": None
+        }
+        resp = session.post(
+            uri,
+            endpoint_filter=self.service,
+            json=body,
+            headers={"Accept": "application/json"}
+        )
+        self._translate_response(resp, has_body=True)
+        return self
+
+    def disconnect_remote_console_access(self, session, server_id):
+        uri = self.base_path % server_id
+        body = {
+            "disconnect-remote-console": None
         }
         resp = session.post(
             uri,

--- a/ecl/baremetal/v2/server.py
+++ b/ecl/baremetal/v2/server.py
@@ -292,7 +292,7 @@ class ServerAction(resource2.Resource):
         uri = self.base_path % server_id
         body = {
             "disconnect-remote-console": None
-          
+
     def update_bmc_password(self, session, server_id, password):
         uri = self.base_path % server_id
         body = {

--- a/ecl/tests/functional/baremetal/test_server_action.py
+++ b/ecl/tests/functional/baremetal/test_server_action.py
@@ -44,6 +44,19 @@ class TestServerAction(base.BaseFunctionalTest):
         self.assertIsInstance(server.user_id, six.string_types)
         self.assertIsInstance(server.password, six.string_types)
 
+    def test_05_get_remote_console_access(self):
+        server = self.conn.baremetal.get_remote_console_access(
+            "91f4e431-ab9d-422e-8f4f-9dcad809d18e",
+        )
+        self.assertIsInstance(server.url, six.string_types)
+        self.assertIsInstance(server.access_code, six.string_types)
+        self.assertIsInstance(server.expired_at, six.string_types)
+
+    def test_06_disconnect_remote_console_access(self):
+        server = self.conn.baremetal.disconnect_remote_console_access(
+            "91f4e431-ab9d-422e-8f4f-9dcad809d18e",
+        )
+
     def test_07_update_bmc_password(self):
         server = self.conn.baremetal.update_bmc_password(
             "91f4e431-ab9d-422e-8f4f-9dcad809d18e",


### PR DESCRIPTION
### Overview
- Add get_remote_console_access and disconnect_remote_console_access to the server API.

### Detail
- ecl/baremetal/v2/_proxy.py
  - Proxy
    - Add get_remote_console_access
    - Add disconnect_remote_console_access

- ecl/baremetal/v2/server.py
  - ServerAction
    - Add get_remote_console_access
    - Add disconnect_remote_console_access
    - Add parameter access_code
    - Add parameter expired_at

- ecl/tests/functional/baremetal/test_server_action.py
  - TestServerAction
    - Add test_05_get_remote_console_access
    - Add test_06_disconnect_remote_console_access