### PR TITLE
✨  Fix to Editing Errors During Conflict Resolution IF-16036

### DIFF
--- a/ecl/baremetal/v2/server.py
+++ b/ecl/baremetal/v2/server.py
@@ -292,6 +292,14 @@ class ServerAction(resource2.Resource):
         uri = self.base_path % server_id
         body = {
             "disconnect-remote-console": None
+        }
+        resp = session.post(
+            uri,
+            endpoint_filter=self.service,
+            json=body
+        )
+        self._translate_response(resp, has_body=False)
+        return self
           
     def update_bmc_password(self, session, server_id, password):
         uri = self.base_path % server_id

--- a/ecl/tests/functional/baremetal/test_server_action.py
+++ b/ecl/tests/functional/baremetal/test_server_action.py
@@ -55,6 +55,7 @@ class TestServerAction(base.BaseFunctionalTest):
     def test_06_disconnect_remote_console_access(self):
         server = self.conn.baremetal.disconnect_remote_console_access(
             "91f4e431-ab9d-422e-8f4f-9dcad809d18e",
+        )
           
     def test_07_update_bmc_password(self):
         server = self.conn.baremetal.update_bmc_password(


### PR DESCRIPTION
### Overview
- Fixed a code error caused by a mistake during conflict resolution.

### Detail
- ecl/baremetal/v2/server.py
  - ServerAction
    - Fix disconnect_remote_console_access

- ecl/tests/functional/baremetal/test_server_action.py
  - TestServerAction
    - Fix test_06_disconnect_remote_console_access